### PR TITLE
Remove python 3.9 from github CI [closes #37]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8,3.9]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
closes #37