### PR TITLE
BROKEN: use single DFK and shutdown executors after workflow ends

### DIFF
--- a/fractal_server/app/runner/__init__.py
+++ b/fractal_server/app/runner/__init__.py
@@ -490,7 +490,7 @@ async def submit_workflow(
     logger.addHandler(fileHandler)
 
     logger.info(f"fractal_server.__VERSION__: {__VERSION__}")
-    logger.info(f"START workflow {workflow.name}")
+    logger.info(f"START {workflow.name=}, {workflow.id=}")
 
     logger.info(f"{input_paths=}")
     logger.info(f"{output_path=}")

--- a/fractal_server/app/runner/runner_utils.py
+++ b/fractal_server/app/runner/runner_utils.py
@@ -379,8 +379,9 @@ def load_parsl_config(
         # Add new executors
         for executor in config.executors:
             if executor.label in current_executor_labels:
-                raise ValueError(f"{executor.label=} already exists")
-        dfk.add_executors(config.executors)
+                warnings.warn(f"{executor.label=} already exists")
+            else:
+                dfk.add_executors([executor])
 
     except RuntimeError:
         logger.info("DFK missing, proceed with a new DataFlowKernel")

--- a/fractal_server/app/runner/runner_utils.py
+++ b/fractal_server/app/runner/runner_utils.py
@@ -379,9 +379,8 @@ def load_parsl_config(
         # Add new executors
         for executor in config.executors:
             if executor.label in current_executor_labels:
-                warnings.warn(f"{executor.label=} already exists")
-            else:
-                dfk.add_executors([executor])
+                raise ValueError(f"{executor.label=} already exists")
+            dfk.add_executors([executor])
 
     except RuntimeError:
         logger.info("DFK missing, proceed with a new DataFlowKernel")
@@ -451,11 +450,13 @@ def shutdown_executors(workflow_id: int):
                 executor.managed and executor.bad_state_is_set
             ):  # and bad_state_is_set
                 logger.warning(
-                    f"Not shutting down executor {executor.label} because it is in bad state"
+                    f"Not shutting down executor {executor.label} because it "
+                    "is in bad state"
                 )
             else:
                 logger.info(
-                    f"Not shutting down executor {executor.label} because it is unmanaged"
+                    f"Not shutting down executor {executor.label} because it "
+                    "is unmanaged"
                 )
 
     for label in labels_to_remove:

--- a/tests/test_apply_worfklow.py
+++ b/tests/test_apply_worfklow.py
@@ -84,14 +84,16 @@ dummy_subtask_parallel = Subtask(
 
 
 @pytest.mark.parametrize(
-    ("task", "message", "nfiles"),
+    ("task", "message", "nfiles", "workflow_id"),
     [
-        (dummy_task, DUMMY_MESSAGE, 1),
-        (dummy_subtask, DUMMY_SUBTASK_MESSAGE, 1),
-        (dummy_subtask_parallel, DUMMY_SUBTASK_MESSAGE, N_INDICES),
+        (dummy_task, DUMMY_MESSAGE, 1, 2),
+        (dummy_subtask, DUMMY_SUBTASK_MESSAGE, 1, 3),
+        (dummy_subtask_parallel, DUMMY_SUBTASK_MESSAGE, N_INDICES, 4),
     ],
 )
-def test_atomic_task_factory(task, message, nfiles, tmp_path, patch_settings):
+def test_atomic_task_factory(
+    task, message, nfiles, workflow_id, tmp_path, patch_settings
+):
     """
     GIVEN
         * a task or subtask
@@ -106,8 +108,6 @@ def test_atomic_task_factory(task, message, nfiles, tmp_path, patch_settings):
 
     from fractal_server.app.runner import _atomic_task_factory
     from fractal_server.app.runner.runner_utils import load_parsl_config
-
-    workflow_id = 0
 
     dfk = load_parsl_config(enable_monitoring=False, workflow_id=workflow_id)
 

--- a/tests/test_apply_worfklow.py
+++ b/tests/test_apply_worfklow.py
@@ -18,7 +18,7 @@ LEN_NONTRIVIAL_WORKFLOW = 3
 @pytest.fixture
 def nontrivial_workflow():
     workflow = Task(
-        id=999,
+        id=99,
         name="outer workflow",
         resource_type="workflow",
         subtask_list=[
@@ -199,7 +199,7 @@ def test_process_workflow_with_wrong_executor(tmp_path, patch_settings):
     from fractal_server.app.runner import _process_workflow
 
     dummy_task = Task(
-        id=999,
+        id=21,
         name="dummy",
         resource_type="core task",
         module="fake_module.dummy:dummy",
@@ -257,6 +257,7 @@ async def test_apply_workflow(
         module=None,
         resource_type="workflow",
         input_type="image",
+        id=30,
     )
 
     stm = select(Task).where(Task.name == "dummy")
@@ -324,6 +325,7 @@ async def test_create_zarr(
         module=None,
         resource_type="workflow",
         input_type="image",
+        id=31,
     )
 
     stm = select(Task).where(Task.name == "Create OME-ZARR structure")
@@ -400,6 +402,7 @@ async def test_yokogawa(
         module=None,
         resource_type="workflow",
         input_type="image",
+        id=31,
     )
 
     stm = select(Task).where(Task.name == "Create OME-ZARR structure")

--- a/tests/test_apply_worfklow.py
+++ b/tests/test_apply_worfklow.py
@@ -52,7 +52,6 @@ def nontrivial_workflow():
             ),
             Subtask(
                 subtask=Task(
-                    id=1001,
                     name="dummy2",
                     module="fractal_tasks_core.dummy:dummy",
                     default_args=dict(message="dummy2", executor="cpu-low"),
@@ -92,7 +91,7 @@ dummy_subtask_parallel = Subtask(
     ],
 )
 def test_atomic_task_factory(
-    task, message, nfiles, workflow_id, tmp_path, patch_settings
+    task, message, nfiles, workflow_id, tmp_path, patch_settings, close_dfk
 ):
     """
     GIVEN
@@ -157,7 +156,9 @@ def test_preprocess_workflow(nontrivial_workflow):
     assert i + 1 == LEN_NONTRIVIAL_WORKFLOW
 
 
-def test_process_workflow(tmp_path, nontrivial_workflow, patch_settings):
+def test_process_workflow(
+    tmp_path, nontrivial_workflow, patch_settings, close_dfk
+):
     """
     GIVEN a nontrivial workflow
     WHEN the workflow is processed
@@ -189,7 +190,9 @@ def test_process_workflow(tmp_path, nontrivial_workflow, patch_settings):
     assert data[2]["message"] == "dummy2"
 
 
-def test_process_workflow_with_wrong_executor(tmp_path, patch_settings):
+def test_process_workflow_with_wrong_executor(
+    tmp_path, patch_settings, close_dfk
+):
     """
     GIVEN a trivial workflow, with an invalid executor
     WHEN the workflow is processed
@@ -227,6 +230,7 @@ async def test_apply_workflow(
     task_factory,
     tmp_path,
     patch_settings,
+    close_dfk,
 ):
     """
     GIVEN
@@ -295,6 +299,7 @@ async def test_create_zarr(
     task_factory,
     tmp_path,
     patch_settings,
+    close_dfk,
 ):
     """
     GIVEN
@@ -372,6 +377,7 @@ async def test_yokogawa(
     task_factory,
     tmp_path,
     patch_settings,
+    close_dfk,
 ):
     """
     GIVEN
@@ -402,7 +408,7 @@ async def test_yokogawa(
         module=None,
         resource_type="workflow",
         input_type="image",
-        id=31,
+        id=32,
     )
 
     stm = select(Task).where(Task.name == "Create OME-ZARR structure")

--- a/tests/test_apply_worfklow.py
+++ b/tests/test_apply_worfklow.py
@@ -138,8 +138,6 @@ def test_atomic_task_factory(task, message, nfiles, tmp_path, patch_settings):
             assert len(data) == 1
             assert data[0]["message"] == message
 
-    dfk.cleanup()
-
 
 def test_preprocess_workflow(nontrivial_workflow):
     """
@@ -189,8 +187,6 @@ def test_process_workflow(tmp_path, nontrivial_workflow, patch_settings):
     assert data[0]["message"] == "dummy0"
     assert data[1]["message"] == "dummy1"
     assert data[2]["message"] == "dummy2"
-
-    dfk.cleanup()
 
 
 def test_process_workflow_with_wrong_executor(tmp_path, patch_settings):

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -36,6 +36,7 @@ async def test_full_workflow(
     testdata_path,
     collect_tasks,
     tmp_path,
+    close_dfk,
 ):
 
     async with MockCurrentUser(persist=True):
@@ -195,6 +196,7 @@ async def test_full_workflow_repeated_tasks(
     MockCurrentUser,
     collect_tasks,
     tmp_path,
+    close_dfk,
 ):
 
     num_subtasks = 3


### PR DESCRIPTION
While debugging for #148, I set up this branch where we go back to a single DFK with multiple executors, but we also shut down executors after the corresponding workflow ends.
Eventually the problem was likely solved through other means (see #149), but I'm keeping this PR here (and closing it right away) for the record.

(a little treat that I included here is a `close_dfk` fixture that closes an active DFK at the end of each test.. it's not needed in current main, but it could be useful if things change)