### PR TITLE
294 test collection of python38 tasks when server is run on python 38

### DIFF
--- a/fractal_server/tasks/collection.py
+++ b/fractal_server/tasks/collection.py
@@ -47,7 +47,7 @@ def get_python_interpreter(version: Optional[str] = None) -> str:
 
     Raises:
         ValueError:
-            If the python version requestsed is not available on the host.
+            If the python version requested is not available on the host.
 
     Returns:
         interpreter:

--- a/fractal_server/tasks/collection.py
+++ b/fractal_server/tasks/collection.py
@@ -10,6 +10,7 @@
 # Zurich.
 import json
 import logging
+import shutil
 import sys
 from io import IOBase
 from pathlib import Path
@@ -34,6 +35,34 @@ from ..utils import set_logger
 
 class TaskCollectionError(RuntimeError):
     pass
+
+
+def get_python_interpreter(version: Optional[str] = None) -> str:
+    """
+    Return the path to the python interpreter
+
+    Args:
+        version:
+            Python version
+
+    Raises:
+        ValueError:
+            If the python version requestsed is not available on the host.
+
+    Returns:
+        interpreter:
+            string representing the python executable or its path
+    """
+    if version:
+        interpreter = shutil.which(f"python{version}")
+        if not interpreter:
+            raise ValueError(
+                f"Python version {version} not available on host."
+            )
+    else:
+        interpreter = sys.executable
+
+    return interpreter
 
 
 def get_absolute_venv_path(venv_path: Path) -> Path:
@@ -168,11 +197,7 @@ async def download_package(
     """
     Download package to destination
     """
-    interpreter = (
-        f"python{task_pkg.python_version}"
-        if task_pkg.python_version
-        else sys.executable
-    )
+    interpreter = get_python_interpreter(version=task_pkg.python_version)
     pip = f"{interpreter} -m pip"
     cmd = (
         f"{pip} download --no-deps {task_pkg.pip_package_version} "
@@ -364,10 +389,7 @@ async def _init_venv(
     python_bin : Path
         path to python interpreter
     """
-    if python_version:
-        interpreter = f"python{python_version}"
-    else:
-        interpreter = sys.executable
+    interpreter = get_python_interpreter(version=python_version)
     await execute_command(
         cwd=path, command=f"{interpreter} -m venv venv", logger_name="fractal"
     )

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -16,6 +16,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Any
 from typing import AsyncGenerator
+from typing import Dict
 from typing import List
 from typing import Optional
 from uuid import uuid4
@@ -30,8 +31,12 @@ from fractal_server.config import get_settings
 from fractal_server.config import Settings
 from fractal_server.syringe import Inject
 
+try:
+    import asyncpg  # noqa: F401
 
-DB_ENGINE = "postgres"
+    DB_ENGINE = "postgres"
+except ModuleNotFoundError:
+    DB_ENGINE = "sqlite"
 
 
 def get_patched_settings(temp_path: Path):
@@ -164,21 +169,24 @@ async def MockCurrentUser(app, db):
         """
 
         name: str = "User Name"
+        user_kwargs: Optional[Dict[str, Any]] = None
         scopes: Optional[List[str]] = field(
             default_factory=lambda: ["project"]
         )
         email: Optional[str] = field(
             default_factory=lambda: f"{uuid4()}@exact-lab.it"
         )
-        persist: Optional[bool] = False
+        persist: Optional[bool] = True
 
         def _create_user(self):
-            self.user = User(
-                name=self.name,
+            defaults = dict(
                 email=self.email,
                 hashed_password="fake_hashed_password",
                 slurm_user="slurm_user",
             )
+            if self.user_kwargs:
+                defaults.update(self.user_kwargs)
+            self.user = User(name=self.name, **defaults)
 
         def current_active_user_override(self):
             def __current_active_user_override():

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -39,6 +39,7 @@ async def collect_tasks(MockCurrentUser, client, dummy_task_package):
     return task_list
 
 
+@pytest.mark.slow
 async def test_full_workflow(
     client,
     MockCurrentUser,

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -4,6 +4,7 @@ from shutil import which as shutil_which
 import pytest
 from devtools import debug
 
+from .fixtures_tasks import execute_command
 from fractal_server.app.api.v1.task import _background_collect_pip
 from fractal_server.app.api.v1.task import _TaskCollectPip
 from fractal_server.app.api.v1.task import create_package_dir_pip
@@ -176,6 +177,10 @@ async def test_collection_api(
         full_path = settings.FRACTAL_ROOT / venv_path
         assert get_collection_path(full_path).exists()
         assert get_log_path(full_path).exists()
+        if python_version:
+            python_bin = data["task_list"][0]["command"].split()[0]
+            version = await execute_command(f"{python_bin} --version")
+            assert python_version in version
 
         # collect again
         res = await client.post(

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from shutil import which as shutil_which
 
 import pytest
 from devtools import debug
@@ -101,7 +102,16 @@ async def test_background_collection_failure(db, dummy_task_package):
 
 @pytest.mark.parametrize(
     ("slurm_user", "python_version"),
-    [("user00", None), ("user01", None)],
+    [
+        ("user00", None),
+        pytest.param(
+            "user01",
+            "3.10",
+            marks=pytest.mark.skipif(
+                not shutil_which("python3.10"), reason="No python3.10 on host"
+            ),
+        ),
+    ],
 )
 async def test_collection_api(
     client, dummy_task_package, MockCurrentUser, slurm_user, python_version

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -99,7 +99,13 @@ async def test_background_collection_failure(db, dummy_task_package):
     assert not venv_path.exists()
 
 
-async def test_collection_api(client, dummy_task_package, MockCurrentUser):
+@pytest.mark.parametrize(
+    ("slurm_user", "python_version"),
+    [("user00", None), ("user01", None)],
+)
+async def test_collection_api(
+    client, dummy_task_package, MockCurrentUser, slurm_user, python_version
+):
     """
     GIVEN a package in a format that `pip` understands
     WHEN the api to collect tasks from that package is called
@@ -113,9 +119,11 @@ async def test_collection_api(client, dummy_task_package, MockCurrentUser):
     """
     PREFIX = "/api/v1/task"
 
-    task_collection = dict(package=dummy_task_package.as_posix())
+    task_collection = dict(
+        package=dummy_task_package.as_posix(), python_version=python_version
+    )
 
-    async with MockCurrentUser(persist=True):
+    async with MockCurrentUser(user_kwargs=dict(slurm_user=slurm_user)):
         # NOTE: collecting private tasks so that they are assigned to user and
         # written in a non-default folder. Bypass for non stateless
         # FRACTAL_ROOT in test suite.

--- a/tests/test_task_collection_pypi.py
+++ b/tests/test_task_collection_pypi.py
@@ -74,8 +74,8 @@ async def test_init_venv(tmp_path, python_version):
     assert (venv_path / "venv/bin/pip").exists()
     assert python_bin.exists()
     assert python_bin == venv_path / "venv/bin/python"
-    version = await execute_command(f"{python_bin} --version")
     if python_version:
+        version = await execute_command(f"{python_bin} --version")
         assert python_version in version
 
 

--- a/tests/test_task_collection_pypi.py
+++ b/tests/test_task_collection_pypi.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from devtools import debug
 
+from .fixtures_tasks import execute_command
 from fractal_server.config import get_settings
 from fractal_server.syringe import Inject
 from fractal_server.tasks.collection import _init_venv
@@ -47,7 +48,8 @@ def test_task_collect_model(dummy_task_package):
     assert tc.package_path == dummy_task_package
 
 
-async def test_init_venv(tmp_path):
+@pytest.mark.parametrize("python_version", [None, "3.10"])
+async def test_init_venv(tmp_path, python_version):
     """
     GIVEN a path and a python version
     WHEN _init_venv() is called
@@ -57,7 +59,14 @@ async def test_init_venv(tmp_path):
     venv_path.mkdir(exist_ok=True, parents=True)
     logger_name = "fractal"
 
-    python_bin = await _init_venv(path=venv_path, logger_name=logger_name)
+    try:
+        python_bin = await _init_venv(
+            path=venv_path,
+            logger_name=logger_name,
+            python_version=python_version,
+        )
+    except ValueError as e:
+        pytest.xfail(reason=str(e))
 
     assert venv_path.exists()
     assert (venv_path / "venv").exists()
@@ -65,6 +74,9 @@ async def test_init_venv(tmp_path):
     assert (venv_path / "venv/bin/pip").exists()
     assert python_bin.exists()
     assert python_bin == venv_path / "venv/bin/python"
+    version = await execute_command(f"{python_bin} --version")
+    if python_version:
+        assert python_version in version
 
 
 async def test_pip_install(tmp_path):


### PR DESCRIPTION
* set automatically database engine in tests by looking for `asyncpg`  (i.e., if you want to automatically run on `sqlite` simply do not `poetry install` the `postgres` extra)

Close #251 