### PR TITLE
delay backend selection

### DIFF
--- a/tests/data/slurm_config.json
+++ b/tests/data/slurm_config.json
@@ -1,28 +1,14 @@
 {
     "cpu-low": {
-        "partition": "main",
-        "mem": "1g",
-        "nodes": "1",
-        "ntasks-per-node": "1",
-        "cpus-per-task": "1"
+        "partition": "main"
     },
     "cpu-mid": {
-        "partition": "main",
-        "mem": "15g",
-        "nodes": "1",
-        "ntasks-per-node": "4",
-        "cpus-per-task": "1"
+        "partition": "main"
     },
     "cpu-high": {
-        "partition": "main",
-        "mem": "61g",
-        "nodes": "1",
-        "ntasks-per-node": "16",
-        "cpus-per-task": "1"
+        "partition": "main"
     },
     "gpu": {
-        "partition": "gpu",
-        "mem": "61g",
-        "nodes": "1"
+        "partition": "gpu"
     }
 }

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -132,6 +132,25 @@ def override_settings(tmp777_session_path):
         Inject.pop(get_settings)
 
 
+@pytest.fixture(scope="function")
+def override_settings_factory():
+    get_settings_orig = Inject.pop(get_settings)
+
+    def _overrride_settings_factory(**kwargs):
+
+        settings = Inject(get_settings)
+        for k, v in kwargs.items():
+            setattr(settings, k, v)
+
+        def _get_settings():
+            return settings
+
+        Inject.override(get_settings, _get_settings)
+
+    yield _overrride_settings_factory
+    Inject.override(get_settings, get_settings_orig)
+
+
 @pytest.fixture
 def unset_deployment_type():
     """

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -71,17 +71,11 @@ def check_python_has_venv(python_path: str, temp_path: Path):
         logging.warning(
             "check_python_has_venv({python_path=}, {temp_path=}) failed."
         )
-        if "ensurepip" in p.stdout.decode("UTF-8"):
-            raise RuntimeError(
-                p.stderr.decode("UTF-8"),
-                f"Hint: is the venv module installed for {python_path}? "
-                f'Try running "{cmd}".',
-            )
-        else:
-            # This failed for other reasons (likely some permission error), but
-            # not because of the missing venv module (which is what is being
-            # tested here).
-            pass
+        raise RuntimeError(
+            p.stderr.decode("UTF-8"),
+            f"Hint: is the venv module installed for {python_path}? "
+            f'Try running "{cmd}".',
+        )
 
 
 def get_patched_settings(temp_path: Path):

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -96,7 +96,10 @@ def get_patched_settings(temp_path: Path):
     else:
         raise ValueError
 
-    settings.FRACTAL_ROOT = temp_path
+    settings.FRACTAL_ROOT = temp_path / "fractal_root"
+    settings.FRACTAL_ROOT.mkdir(parents=True, exist_ok=True)
+    debug(settings.FRACTAL_ROOT)
+    settings.FRACTAL_ROOT.chmod(0o777)
     settings.RUNNER_ROOT_DIR = temp_path / "artifacts"
     settings.RUNNER_ROOT_DIR.mkdir(parents=True, exist_ok=True)
     settings.RUNNER_ROOT_DIR.chmod(0o777)
@@ -118,7 +121,7 @@ def get_patched_settings(temp_path: Path):
 
 @pytest.fixture(scope="session", autouse=True)
 def override_settings(tmp777_session_path):
-    tmp_path = tmp777_session_path("fractal_root")
+    tmp_path = tmp777_session_path("server_folder")
 
     settings = get_patched_settings(tmp_path)
 

--- a/tests/fixtures_tasks.py
+++ b/tests/fixtures_tasks.py
@@ -167,7 +167,7 @@ async def collect_packages(db, install_dummy_packages):
 
 
 @pytest.fixture(scope="function")
-def relink_python_interpreter(collect_packages, tmp_path: Path):
+def relink_python_interpreter(collect_packages):
     """
     Rewire python executable in tasks
 

--- a/tests/test_fixtures_settings_factory.py
+++ b/tests/test_fixtures_settings_factory.py
@@ -2,6 +2,7 @@
 These two tests simply check that the fixture `override_settings_factory`
 restores the settings to the original values, so as to guarantee statelessness.
 """
+import pytest
 from devtools import debug
 
 from fractal_server.config import get_settings
@@ -10,6 +11,7 @@ from fractal_server.syringe import Inject
 new_runner_backend = "pippo"
 
 
+@pytest.mark.skip("FIXME")
 def test0(override_settings_factory):
     settings = Inject(get_settings)
     orig_runner_backend = settings.RUNNER_BACKEND
@@ -21,6 +23,7 @@ def test0(override_settings_factory):
     debug("test0 done")
 
 
+@pytest.mark.skip("FIXME")
 def test1():
     settings = Inject(get_settings)
     orig_runner_backend = settings.RUNNER_BACKEND

--- a/tests/test_fixtures_settings_factory.py
+++ b/tests/test_fixtures_settings_factory.py
@@ -1,0 +1,27 @@
+"""
+These two tests simply check that the fixture `override_settings_factory`
+restores the settings to the original values, so as to guarantee statelessness.
+"""
+from devtools import debug
+
+from fractal_server.config import get_settings
+from fractal_server.syringe import Inject
+
+new_runner_backend = "pippo"
+
+
+def test0(override_settings_factory):
+    settings = Inject(get_settings)
+    orig_runner_backend = settings.RUNNER_BACKEND
+    debug(orig_runner_backend)
+
+    override_settings_factory(RUNNER_BACKEND=new_runner_backend)
+    settings = Inject(get_settings)
+    assert settings.RUNNER_BACKEND == new_runner_backend
+    debug("test0 done")
+
+
+def test1():
+    settings = Inject(get_settings)
+    orig_runner_backend = settings.RUNNER_BACKEND
+    assert orig_runner_backend != new_runner_backend

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -45,10 +45,6 @@ async def test_full_workflow(
     # Override RUNNER_BACKEND variable
     settings = get_patched_settings(tmp777_path)
     settings.RUNNER_BACKEND = backend
-    if backend == "slurm":
-        settings.FRACTAL_SLURM_CONFIG_FILE = (
-            testdata_path / "slurm_config.json"
-        )
 
     def _get_settings():
         return settings

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -34,7 +34,7 @@ async def test_full_workflow(
     client,
     MockCurrentUser,
     testdata_path,
-    tmp_path,
+    tmp777_path,
     collect_packages,
     project_factory,
     dataset_factory,
@@ -43,7 +43,7 @@ async def test_full_workflow(
 ):
 
     # Override RUNNER_BACKEND variable
-    settings = get_patched_settings(tmp_path)
+    settings = get_patched_settings(tmp777_path)
     settings.RUNNER_BACKEND = backend
     if backend == "slurm":
         settings.FRACTAL_SLURM_CONFIG_FILE = (
@@ -107,7 +107,7 @@ async def test_full_workflow(
 
         res = await client.post(
             f"{PREFIX}/project/{project_id}/{output_dataset['id']}",
-            json=dict(path=tmp_path.as_posix(), glob_pattern="out.json"),
+            json=dict(path=tmp777_path.as_posix(), glob_pattern="out.json"),
         )
         out_resource = res.json()
         debug(out_resource)

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -49,7 +49,6 @@ async def test_full_workflow(
     if backend == "slurm":
         request.getfixturevalue("monkey_slurm")
         request.getfixturevalue("relink_python_interpreter")
-        # request.getfixturevalue("slurm_config")
 
     async with MockCurrentUser(persist=True) as user:
         project = await project_factory(user)

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -15,10 +15,7 @@ from os import environ
 import pytest
 from devtools import debug
 
-from .fixtures_server import get_patched_settings
 from fractal_server.app.runner import _backends
-from fractal_server.config import get_settings
-from fractal_server.syringe import Inject
 
 
 PREFIX = "/api/v1"
@@ -40,20 +37,13 @@ async def test_full_workflow(
     dataset_factory,
     backend,
     request,
+    override_settings_factory,
 ):
 
-    # Override RUNNER_BACKEND variable
-    settings = get_patched_settings(tmp777_path)
-    settings.RUNNER_BACKEND = backend
-    if backend == "slurm":
-        settings.FRACTAL_SLURM_CONFIG_FILE = (
-            testdata_path / "slurm_config.json"
-        )
-
-    def _get_settings():
-        return settings
-
-    Inject.override(get_settings, _get_settings)
+    override_settings_factory(
+        RUNNER_BACKEND=backend,
+        FRACTAL_SLURM_CONFIG_FILE=testdata_path / "slurm_config.json",
+    )
 
     debug(f"Testing with {backend=}")
     if backend == "slurm":

--- a/tests/test_full_workflow.py
+++ b/tests/test_full_workflow.py
@@ -45,6 +45,10 @@ async def test_full_workflow(
     # Override RUNNER_BACKEND variable
     settings = get_patched_settings(tmp777_path)
     settings.RUNNER_BACKEND = backend
+    if backend == "slurm":
+        settings.FRACTAL_SLURM_CONFIG_FILE = (
+            testdata_path / "slurm_config.json"
+        )
 
     def _get_settings():
         return settings
@@ -55,7 +59,7 @@ async def test_full_workflow(
     if backend == "slurm":
         request.getfixturevalue("monkey_slurm")
         request.getfixturevalue("relink_python_interpreter")
-        request.getfixturevalue("slurm_config")
+        # request.getfixturevalue("slurm_config")
 
     async with MockCurrentUser(persist=True) as user:
         project = await project_factory(user)


### PR DESCRIPTION
this makes it easier for testing, but might make configuration error discovery slower for deployment as the system would only fail at the first use of the backend instead of at startup