### PR TITLE
setup database from `fractalctl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           DATA_DIR_ROOT: /tmp/fractal-server/
           FRACTAL_TASKS_DIR: /tmp/fractal-server/tasks/
           FRACTAL_RUNNER_WORKING_BASE_DIR: /tmp/fractal-server/artifacts/
-        run: poetry run openapi
+        run: poetry run fractalctl openapi
 
       - name: Upload openapi schema
         uses: actions/upload-artifact@v3

--- a/fractal_server/__main__.py
+++ b/fractal_server/__main__.py
@@ -4,13 +4,16 @@ from sys import argv
 import uvicorn
 
 parser = ap.ArgumentParser()
-parser.add_argument("--host", default="127.0.0.1")
-parser.add_argument("-p", "--port", default=8000, type=int)
-parser.add_argument("--reload", default=False, action="store_true")
 
-subparsers = parser.add_subparsers(title="Commands", dest="cmd")
-subparsers.add_parser("start", help="Start the server (default behaviour)")
+subparsers = parser.add_subparsers(title="Commands", dest="cmd", required=True)
 
+# fractalctl start
+startserver = subparsers.add_parser("start", help="Start the server")
+startserver.add_argument("--host", default="127.0.0.1")
+startserver.add_argument("-p", "--port", default=8000, type=int)
+startserver.add_argument("--reload", default=False, action="store_true")
+
+# fractalctl openapi
 openapi_parser = subparsers.add_parser(
     "openapi", help="Save the `openapi.json` file"
 )
@@ -21,25 +24,8 @@ openapi_parser.add_argument(
     default="openapi.json",
 )
 
+# fractalctl set-db
 subparsers.add_parser("set-db", help="Initialise the database")
-
-
-def run():
-    args = parser.parse_args(argv[1:])
-    from devtools import debug
-
-    debug(args)
-    if args.cmd == "openapi":
-        save_openapi(dest=args.openapi_file)
-    elif args.cmd == "set-db":
-        set_db()
-    else:
-        uvicorn.run(
-            "fractal_server.main:app",
-            host=args.host,
-            port=args.port,
-            reload=args.reload,
-        )
 
 
 def save_openapi(dest="openapi.json"):
@@ -69,6 +55,22 @@ def set_db():
     alembic_args = ["-c", alembic_ini.as_posix(), "upgrade", "head"]
 
     alembic.config.main(argv=alembic_args)
+
+
+def run():
+    args = parser.parse_args(argv[1:])
+
+    if args.cmd == "openapi":
+        save_openapi(dest=args.openapi_file)
+    elif args.cmd == "set-db":
+        set_db()
+    else:
+        uvicorn.run(
+            "fractal_server.main:app",
+            host=args.host,
+            port=args.port,
+            reload=args.reload,
+        )
 
 
 if __name__ == "__main__":

--- a/fractal_server/__main__.py
+++ b/fractal_server/__main__.py
@@ -54,6 +54,7 @@ def set_db():
     alembic_ini = Path(fractal_server.__file__).parent / "alembic.ini"
     alembic_args = ["-c", alembic_ini.as_posix(), "upgrade", "head"]
 
+    print(f"Run alembic.config, with argv={alembic_args}")
     alembic.config.main(argv=alembic_args)
 
 

--- a/fractal_server/__main__.py
+++ b/fractal_server/__main__.py
@@ -8,26 +8,67 @@ parser.add_argument("--host", default="127.0.0.1")
 parser.add_argument("-p", "--port", default=8000, type=int)
 parser.add_argument("--reload", default=False, action="store_true")
 
+subparsers = parser.add_subparsers(title="Commands", dest="cmd")
+subparsers.add_parser("start", help="Start the server (default behaviour)")
+
+openapi_parser = subparsers.add_parser(
+    "openapi", help="Save the `openapi.json` file"
+)
+openapi_parser.add_argument(
+    "-f",
+    "--openapi-file",
+    help="Filename for OpenAPI schema dump",
+    default="openapi.json",
+)
+
+subparsers.add_parser("set-db", help="Initialise the database")
+
 
 def run():
     args = parser.parse_args(argv[1:])
-    uvicorn.run(
-        "fractal_server.main:app",
-        host=args.host,
-        port=args.port,
-        reload=args.reload,
-    )
+    from devtools import debug
+
+    debug(args)
+    if args.cmd == "openapi":
+        save_openapi(dest=args.openapi_file)
+    elif args.cmd == "set-db":
+        set_db()
+    else:
+        uvicorn.run(
+            "fractal_server.main:app",
+            host=args.host,
+            port=args.port,
+            reload=args.reload,
+        )
 
 
-def save_openapi():
+def save_openapi(dest="openapi.json"):
     from fractal_server.main import start_application
     import json
 
     app = start_application()
     openapi_schema = app.openapi()
 
-    with open("openapi.json", "w") as f:
+    with open(dest, "w") as f:
         json.dump(openapi_schema, f)
+
+
+def set_db():
+    """
+    Set-up / Upgrade database schema
+
+    Call alembic to upgrade to the latest migration.
+
+    Ref: https://stackoverflow.com/a/56683030/283972
+    """
+    import alembic.config
+    from pathlib import Path
+    import fractal_server
+
+    alembic_ini = Path(fractal_server.__file__).parent / "alembic.ini"
+    alembic_args = ["-c", alembic_ini.as_posix(), "upgrade", "head"]
+
+    alembic.config.main(argv=alembic_args)
 
 
 if __name__ == "__main__":

--- a/fractal_server/alembic.ini
+++ b/fractal_server/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = fractal_server/migrations/
+script_location = %(here)s/migrations/
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,7 @@ push = true
 ]
 
 [tool.poetry.scripts]
-fractal-server = "fractal_server.__main__:run"
-openapi = "fractal_server.__main__:save_openapi"
+fractalctl = "fractal_server.__main__:run"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Introduce a single entrypoint `fractalctl` (`__main__` of the package) which allows to
* run the server
* save the openapi schema
* run the database migration

Close #357