### PR TITLE
Test all relevant `/users` routers

### DIFF
--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -246,7 +246,7 @@ async def client(
 
 
 @pytest.fixture
-async def client_register(
+async def registered_client(
     app: FastAPI, register_routers, db
 ) -> AsyncGenerator[AsyncClient, Any]:
     async with AsyncClient(

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -246,6 +246,26 @@ async def client(
 
 
 @pytest.fixture
+async def client_register(
+    app: FastAPI, register_routers, db
+) -> AsyncGenerator[AsyncClient, Any]:
+    async with AsyncClient(
+        app=app, base_url="http://test"
+    ) as client, LifespanManager(app):
+        data_register = dict(
+            email="test@test.com", slurm_user="test", password="123"
+        )
+        data_login = dict(
+            username="test@test.com", password="123", slurm_user="test"
+        )
+        res = await client.post("auth/register", json=data_register)
+        res = await client.post("auth/token/login", data=data_login)
+        token = res.json()["access_token"]
+        client.headers["Authorization"] = f"Bearer {token}"
+        yield client
+
+
+@pytest.fixture
 async def MockCurrentUser(app, db):
     from fractal_server.app.security import current_active_user
     from fractal_server.app.security import User

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -17,7 +17,7 @@ async def test_me_known(client):
     )
 
     data_login = dict(
-        username="test@test.com", password="123", lurm_user="test"
+        username="test@test.com", password="123", slurm_user="test"
     )
     res = await client.post(f"{PREFIX}/register", json=data_register)
     res = await client.post(f"{PREFIX}/token/login", data=data_login)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -4,8 +4,25 @@ from devtools import debug
 PREFIX = "/auth"
 
 
-async def test_me(app, client, MockCurrentUser):
+async def test_me_unkonwn(client):
     # Anonymous
     res = await client.get(f"{PREFIX}/users/me")
     debug(res.json())
     assert res.status_code == 401
+
+
+async def test_me_known(client):
+    data_register = dict(
+        email="test@test.com", slurm_user="test", password="123"
+    )
+
+    data_login = dict(
+        username="test@test.com", password="123", lurm_user="test"
+    )
+    res = await client.post(f"{PREFIX}/register", json=data_register)
+    res = await client.post(f"{PREFIX}/token/login", data=data_login)
+    token = res.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    res = await client.get(f"{PREFIX}/users/me")
+    debug(res.json())
+    assert res.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -11,7 +11,7 @@ async def test_me_unkonwn(client):
     assert res.status_code == 401
 
 
-async def test_me_known(client_register):
-    res = await client_register.get(f"{PREFIX}/users/me")
+async def test_me_known(registered_client):
+    res = await registered_client.get(f"{PREFIX}/users/me")
     debug(res.json())
     assert res.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -11,18 +11,7 @@ async def test_me_unkonwn(client):
     assert res.status_code == 401
 
 
-async def test_me_known(client):
-    data_register = dict(
-        email="test@test.com", slurm_user="test", password="123"
-    )
-
-    data_login = dict(
-        username="test@test.com", password="123", slurm_user="test"
-    )
-    res = await client.post(f"{PREFIX}/register", json=data_register)
-    res = await client.post(f"{PREFIX}/token/login", data=data_login)
-    token = res.json()["access_token"]
-    client.headers["Authorization"] = f"Bearer {token}"
-    res = await client.get(f"{PREFIX}/users/me")
+async def test_me_known(client_register):
+    res = await client_register.get(f"{PREFIX}/users/me")
     debug(res.json())
     assert res.status_code == 200


### PR DESCRIPTION
requires: #403 
closes #433 
ref #442

Possible simplification
- [x] Modify `client` fixture, by including the header as in the current test for `/users/me`.