### PR TITLE
Attempts to fix CI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2626,4 +2626,4 @@ slurm = ["clusterfutures"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "7697371c59bf51985570190a38ccba66166f6bb76532497b575a2959eefab59c"
+content-hash = "45de1058f32e9d0c3a840e0c4bb7a0d6a7c1e1490524b3b3b5e5c12e039b11d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ fastapi-users = {extras = ["oauth"], version = "^10.1"}
 fastapi-users-db-sqlmodel = "^0.2.0"
 alembic = "^1.9.1"
 uvicorn = "^0.20.0"
+sqlalchemy = "^1.4"
 SQLAlchemy-Utils = "^0.38.3"
 
 clusterfutures = { version = "^0.5", optional = true }

--- a/tests/data/slurm_docker_images/node/Dockerfile
+++ b/tests/data/slurm_docker_images/node/Dockerfile
@@ -2,6 +2,6 @@ FROM rancavil/slurm-node:19.05.5-1
 
 COPY slurm.conf /etc/slurm-llnl/
 ADD fractal_server_local.tar.gz .
-RUN pip3 install ./fractal_server_local.tar.gz[slurm]
+RUN pip3 install ./fractal-server[slurm]
 
 ENTRYPOINT ["/etc/slurm-llnl/docker-entrypoint.sh"]

--- a/tests/data/slurm_docker_images/node/Dockerfile
+++ b/tests/data/slurm_docker_images/node/Dockerfile
@@ -2,6 +2,6 @@ FROM rancavil/slurm-node:19.05.5-1
 
 COPY slurm.conf /etc/slurm-llnl/
 ADD fractal_server_local.tar.gz .
-RUN pip3 install ./fractal-server[slurm]
+RUN pip3 install ./fractal_server_local.tar.gz[slurm]
 
 ENTRYPOINT ["/etc/slurm-llnl/docker-entrypoint.sh"]

--- a/tests/test_backend_runners.py
+++ b/tests/test_backend_runners.py
@@ -48,6 +48,7 @@ async def test_runner(
         request.getfixturevalue("monkey_slurm")
         request.getfixturevalue("relink_python_interpreter")
         request.getfixturevalue("slurm_config")
+        request.getfixturevalue("cfut_jobs_finished")
 
     process_workflow = _backends[backend]
 

--- a/tests/test_backend_slurm.py
+++ b/tests/test_backend_slurm.py
@@ -205,7 +205,7 @@ def test_unit_slurm_config():
     ),
 )
 def test_sbatch_script_slurm_config(
-    tmp_path, slurm_config, slurm_config_key, task
+    tmp_path, slurm_config, slurm_config_key, task, cfut_jobs_finished
 ):
     """
     GIVEN


### PR DESCRIPTION
Refs:
* #479
* #481

We found a major issue in the CI (thanks @ychiucco!), i.e. fractal-server install in docker container was pulling the fresh sqlalchemy 2.0 version (released yesterday), which introduces major changes and is not (yet) supported by our dependencies.

This is currently addressed by pinning to >=1.4,<2, and we should also come back to this later if a PR like https://github.com/fastapi-users/fastapi-users-db-sqlmodel/pull/13 is merged (I think this is the dependency which is currently holding us back at 1.4.35), to make sure that we would fetch more recent 1.4 versions if possible.

Meanwhile, another small issue (`cfut_finished_jobs` fixture missing in some tests, and its actual code being slightly different from the cfut=0.5 final version) surfaced, and is fixed here.