### PR TITLE
CI: cleanup permissions after tests

### DIFF
--- a/tests/data/slurm_docker_images/master/sudoers
+++ b/tests/data/slurm_docker_images/master/sudoers
@@ -20,7 +20,7 @@ Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 root	ALL=(ALL:ALL) ALL
 
 Runas_Alias FRACTAL_IMPERSONATE_USERS = fractal, test01
-Cmnd_Alias FRACTAL_CMD = /usr/bin/sbatch, /usr/bin/scancel, /usr/bin/cat, /usr/bin/ls, /usr/bin/mkdir
+Cmnd_Alias FRACTAL_CMD = /usr/bin/sbatch, /usr/bin/scancel, /usr/bin/cat, /usr/bin/ls, /usr/bin/mkdir, /usr/bin/chmod
 fractal ALL=(FRACTAL_IMPERSONATE_USERS) NOPASSWD:FRACTAL_CMD
 
 # Members of the admin group may gain root privileges

--- a/tests/test_backend_runners.py
+++ b/tests/test_backend_runners.py
@@ -84,10 +84,9 @@ async def test_runner(
         workflow_dir.mkdir(parents=True, mode=0o700)
         os.umask(umask)
     elif backend == "slurm":
-        from .test_backend_slurm import _define_and_create_folders
-
-        folders = _define_and_create_folders(tmp777_path, monkey_slurm_user)
-        workflow_dir, workflow_dir_user = folders[:]
+        workflow_dir, workflow_dir_user = request.getfixturevalue(
+            "slurm_working_folders"
+        )  # noqa
 
     # Prepare backend-specific arguments
     logger_name = "job_logger"


### PR DESCRIPTION
Close #484 

For tests using the docker SLURM clusters, some files/folders belong to a specific user, and then pytest cannot remove them after execution.
With the current update, we use a fixture that makes these files 777 after execution, so that pytest can remove them.