### PR TITLE
Update `local` backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop `project.project_dir` and replace it with `user.cache_dir` (\#601).
 * Update SLURM backend (\#582, \#612, \#614); this includes (1) combining several tasks in a single SLURM job, and (2) offering more granular sources for SLURM configuration options.
 * Expose local user exports in SLURM configuration file (\#625).
+* Make local backend rely on custom `FractalThreadPoolExecutor`, where `parallel_tasks_per_job` can affect parallelism (\#626).
 * Review logging configuration (\#619, \#623).
 * Update to fastapi `0.95` (\#587).
 * Minor improvements in dataset-edit endpoint (\#593) and tests (\#589).

--- a/docs/internals/runners/index.md
+++ b/docs/internals/runners/index.md
@@ -4,9 +4,8 @@ Runner backends are responsible for scheduling and applying (running) tasks on
 your data. Fractal currently supports two backends:
 
 * [local](local.md):
-    This is the reference backend implementation. It is mostly useful for
-    testing purposes, as it runs tasks locally on the same host where the
-    server is installed.
+    This is the reference backend implementation, which runs tasks locally on
+    the same host where the server is installed.
 * [SLURM](slurm.md):
     Run tasks by scheduling them on a SLURM cluster.
 

--- a/docs/internals/runners/local.md
+++ b/docs/internals/runners/local.md
@@ -1,3 +1,40 @@
 # Local backend
 
-In-progress (for the moment, refer to the [local](../../../reference/fractal_server/app/runner/_local) module).
+(refer to the [local](../../../reference/fractal_server/app/runner/_local) module for more details)
+
+## Configuration
+
+The logic for setting up the local-backend configuration of a given `WorkflowTask` is
+implemented in the
+[local.\_local_config](../../../reference/fractal_server/app/runner/_local/_local_config)
+submodule.
+
+For the moment, this configuration includes a single (optional) parameter,
+namely the ingeger variable `parallel_tasks_per_job`. This parameter is related
+to tasks that needs to be run in parallel over several inputs: When
+`parallel_tasks_per_job` is set, it will represent the maximum number of tasks
+that the backend will run at the same time.
+
+The typical intended use case is that setting `parallel_tasks_per_job` to a
+small number (e.g. `1`) will limit parallelism when executing tasks requiring a
+large amount of resources (e.g. memory).
+
+
+The different sources for `parallel_tasks_per_job` are:
+
+1. If the `WorkflowTask.meta` field has a `parallel_tasks_per_job` key, the
+   corresponding value takes highest priority;
+2. Next priority goes to a `parallel_tasks_per_job` entry in
+   `WorkflowTask.task.meta`;
+3. Next priority goes to the configuration in `FRACTAL_LOCAL_CONFIG_FILE`, a
+   JSON file that may contain a definition of a
+   [`LocalBackendConfig`](../../../reference/fractal_server/app/runner/_local/_local_config/#fractal_server.app.runner._local._local_config.LocalBackendConfig)
+   object like
+```JSON
+{
+  "parallel_tasks_per_job": 1
+}
+```
+4. Lowest-priority (that is, the default) is to set
+   `parallel_tasks_per_job=None`, which corresponds to _not_ limiting
+    parallelism at all.

--- a/docs/internals/runners/slurm.md
+++ b/docs/internals/runners/slurm.md
@@ -1,7 +1,7 @@
 # SLURM backend
 
-In-progress (for the moment, refer to the
-[slurm](../../../reference/fractal_server/app/runner/_slurm) module).
+(refer to the [slurm](../../../reference/fractal_server/app/runner/_slurm)
+module for more details)
 
 ## SLURM configuration
 

--- a/fractal_server/app/runner/_common.py
+++ b/fractal_server/app/runner/_common.py
@@ -534,6 +534,7 @@ def recursive_task_submission(
         workflow_dir_user=workflow_dir_user,
         submit_setup_call=submit_setup_call,
         logger_name=logger_name,
+        submit_setup_call=submit_setup_call,
     )
     # Wait for dependencies to be complete (NOTE: this is not necessary if we
     # explicitly wait for the result of executor.submit(call_single_task, ...),

--- a/fractal_server/app/runner/_common.py
+++ b/fractal_server/app/runner/_common.py
@@ -534,7 +534,6 @@ def recursive_task_submission(
         workflow_dir_user=workflow_dir_user,
         submit_setup_call=submit_setup_call,
         logger_name=logger_name,
-        submit_setup_call=submit_setup_call,
     )
     # Wait for dependencies to be complete (NOTE: this is not necessary if we
     # explicitly wait for the result of executor.submit(call_single_task, ...),

--- a/fractal_server/app/runner/_local/__init__.py
+++ b/fractal_server/app/runner/_local/__init__.py
@@ -1,12 +1,12 @@
 """
 Local Bakend
 
-This backend runs Fractal workflows using python
-[ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
-to run tasks in several threads. Incidentally, it also represents the reference
-implementation for a backend.
+This backend runs Fractal workflows using `FractalThreadPoolExecutor` (a custom
+version of Python
+[ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor))
+to run tasks in several threads.
+Incidentally, it also represents the reference implementation for a backend.
 """
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 from typing import Optional
@@ -16,6 +16,7 @@ from .._common import recursive_task_submission
 from ..common import async_wrap
 from ..common import TaskParameters
 from ._submit_setup import _local_submit_setup
+from .executor import FractalThreadPoolExecutor
 
 
 def _process_workflow(
@@ -36,7 +37,7 @@ def _process_workflow(
     for the call signature.
     """
 
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         output_task_pars_fut = recursive_task_submission(
             executor=executor,
             task_list=workflow.task_list,

--- a/fractal_server/app/runner/_local/__init__.py
+++ b/fractal_server/app/runner/_local/__init__.py
@@ -1,3 +1,15 @@
+# Copyright 2022 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Jacopo Nespolo <jacopo.nespolo@exact-lab.it>
+# Tommaso Comparin <tommaso.comparin@exact-lab.it>
+# Marco Franzon <marco.franzon@exact-lab.it>
+#
+# This file is part of Fractal and was originally developed by eXact lab S.r.l.
+# <exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+# Institute for Biomedical Research and Pelkmans Lab from the University of
+# Zurich.
 """
 Local Bakend
 

--- a/fractal_server/app/runner/_local/__init__.py
+++ b/fractal_server/app/runner/_local/__init__.py
@@ -43,7 +43,7 @@ def _process_workflow(
     """
     Internal processing routine
 
-    Schedules the workflow using a ThreadPoolExecutor.
+    Schedules the workflow using a `FractalThreadPoolExecutor`.
 
     Cf. [process_workflow][fractal_server.app.runner._local.process_workflow]
     for the call signature.

--- a/fractal_server/app/runner/_local/__init__.py
+++ b/fractal_server/app/runner/_local/__init__.py
@@ -15,6 +15,7 @@ from ...models import Workflow
 from .._common import recursive_task_submission
 from ..common import async_wrap
 from ..common import TaskParameters
+from ._submit_setup import _local_submit_setup
 
 
 def _process_workflow(
@@ -47,6 +48,7 @@ def _process_workflow(
             workflow_dir=workflow_dir,
             workflow_dir_user=workflow_dir,
             logger_name=logger_name,
+            submit_setup_call=_local_submit_setup,
         )
     output_task_pars = output_task_pars_fut.result()
     output_dataset_metadata = output_task_pars.metadata

--- a/fractal_server/app/runner/_local/_local_config.py
+++ b/fractal_server/app/runner/_local/_local_config.py
@@ -75,7 +75,7 @@ def get_local_backend_config(
             prepared.
         config_path:
             Path of local-backend configuration file; if `None`, use
-            `FRACTAL_LOCAL_RUNNER_CONFIG_FILE` variable from settings.
+            `FRACTAL_LOCAL_CONFIG_FILE` variable from settings.
 
     Returns:
         A local-backend configuration object
@@ -89,7 +89,7 @@ def get_local_backend_config(
     else:
         if not config_path:
             settings = Inject(get_settings)
-            config_path = settings.FRACTAL_RUNNER_LOCAL_CONFIG_FILE
+            config_path = settings.FRACTAL_LOCAL_CONFIG_FILE
         if config_path is None:
             parallel_tasks_per_job = default
         else:

--- a/fractal_server/app/runner/_local/_local_config.py
+++ b/fractal_server/app/runner/_local/_local_config.py
@@ -61,7 +61,7 @@ def get_local_backend_config(
     Prepare a `LocalBackendConfig` configuration object
 
     The sources for `parallel_tasks_per_job` attributes, starting from the
-    higest-priority one, are
+    highest-priority one, are
 
     1. Properties in `wftask.meta`;
     2. Properties in `wftask.task.meta` (this is already included in

--- a/fractal_server/app/runner/_local/_local_config.py
+++ b/fractal_server/app/runner/_local/_local_config.py
@@ -83,24 +83,27 @@ def get_local_backend_config(
     key = "parallel_tasks_per_job"
     default = None
 
-    if key in wftask.meta.keys():
+    if wftask.meta and key in wftask.meta.keys():
         parallel_tasks_per_job = wftask.meta[key]
-    elif key in wftask.task.meta.keys():
+    elif wftask.task.meta and key in wftask.task.meta.keys():
         parallel_tasks_per_job = wftask.task.meta[key]
     else:
         if not config_path:
             settings = Inject(get_settings)
             config_path = settings.FRACTAL_RUNNER_LOCAL_CONFIG_FILE
-        with config_path.open("r") as f:
-            env = json.load(f)
-        try:
-            _ = LocalBackendConfig(**env)
-        except ValidationError as e:
-            raise LocalBackendConfigError(
-                f"Error while loading {config_path=}. "
-                f"Original error:\n{str(e)}"
-            )
+        if config_path is None:
+            parallel_tasks_per_job = default
+        else:
+            with config_path.open("r") as f:
+                env = json.load(f)
+            try:
+                _ = LocalBackendConfig(**env)
+            except ValidationError as e:
+                raise LocalBackendConfigError(
+                    f"Error while loading {config_path=}. "
+                    f"Original error:\n{str(e)}"
+                )
 
-        parallel_tasks_per_job = env.get(key, default)
+            parallel_tasks_per_job = env.get(key, default)
 
     return LocalBackendConfig(parallel_tasks_per_job=parallel_tasks_per_job)

--- a/fractal_server/app/runner/_local/_local_config.py
+++ b/fractal_server/app/runner/_local/_local_config.py
@@ -63,10 +63,11 @@ def get_local_backend_config(
     The sources for `parallel_tasks_per_job` attributes, starting from the
     higest-priority one, are
 
-    1. Properties in `wftask.meta`.
-    2. Properties in `wftask.task.meta`.
-    3. The general content of the local-backend configuration file.
-    4. The default value (`None`)
+    1. Properties in `wftask.meta`;
+    2. Properties in `wftask.task.meta` (this is already included in
+       overridden_meta);
+    3. The general content of the local-backend configuration file;
+    4. The default value (`None`).
 
     Arguments:
         wftask:
@@ -83,10 +84,8 @@ def get_local_backend_config(
     key = "parallel_tasks_per_job"
     default = None
 
-    if wftask.meta and key in wftask.meta.keys():
-        parallel_tasks_per_job = wftask.meta[key]
-    elif wftask.task.meta and key in wftask.task.meta.keys():
-        parallel_tasks_per_job = wftask.task.meta[key]
+    if wftask.overridden_meta and key in wftask.overridden_meta.keys():
+        parallel_tasks_per_job = wftask.overridden_meta[key]
     else:
         if not config_path:
             settings = Inject(get_settings)

--- a/fractal_server/app/runner/_local/_local_config.py
+++ b/fractal_server/app/runner/_local/_local_config.py
@@ -1,0 +1,106 @@
+# Copyright 2022 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Tommaso Comparin <tommaso.comparin@exact-lab.it>
+#
+# This file is part of Fractal and was originally developed by eXact lab S.r.l.
+# <exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+# Institute for Biomedical Research and Pelkmans Lab from the University of
+# Zurich.
+"""
+Submodule to handle the local-backend configuration for a WorkflowTask
+"""
+import json
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Extra
+from pydantic.error_wrappers import ValidationError
+
+from ....config import get_settings
+from ....syringe import Inject
+from ...models import WorkflowTask
+
+
+class LocalBackendConfigError(ValueError):
+    """
+    Local-backend configuration error
+    """
+
+    pass
+
+
+class LocalBackendConfig(BaseModel, extra=Extra.forbid):
+    """
+    Specifications of the local-backend configuration
+
+    Attributes:
+        parallel_tasks_per_job:
+            Maximum number of tasks to be run in parallel as part of a call to
+            `FractalThreadPoolExecutor.map`; if `None`, then all tasks will
+            start at the same time.
+    """
+
+    parallel_tasks_per_job: Optional[int]
+
+
+def get_default_local_backend_config():
+    """
+    Return a default `LocalBackendConfig` configuration object
+    """
+    return LocalBackendConfig(parallel_tasks_per_job=None)
+
+
+def get_local_backend_config(
+    wftask: WorkflowTask,
+    config_path: Optional[Path] = None,
+) -> LocalBackendConfig:
+    """
+    Prepare a `LocalBackendConfig` configuration object
+
+    The sources for `parallel_tasks_per_job` attributes, starting from the
+    higest-priority one, are
+
+    1. Properties in `wftask.meta`.
+    2. Properties in `wftask.task.meta`.
+    3. The general content of the local-backend configuration file.
+    4. The default value (`None`)
+
+    Arguments:
+        wftask:
+            WorkflowTask for which the backend configuration is is to be
+            prepared.
+        config_path:
+            Path of local-backend configuration file; if `None`, use
+            `FRACTAL_LOCAL_RUNNER_CONFIG_FILE` variable from settings.
+
+    Returns:
+        A local-backend configuration object
+    """
+
+    key = "parallel_tasks_per_job"
+    default = None
+
+    if key in wftask.meta.keys():
+        parallel_tasks_per_job = wftask.meta[key]
+    elif key in wftask.task.meta.keys():
+        parallel_tasks_per_job = wftask.task.meta[key]
+    else:
+        if not config_path:
+            settings = Inject(get_settings)
+            config_path = settings.FRACTAL_RUNNER_LOCAL_CONFIG_FILE
+        with config_path.open("r") as f:
+            env = json.load(f)
+        try:
+            _ = LocalBackendConfig(**env)
+        except ValidationError as e:
+            raise LocalBackendConfigError(
+                f"Error while loading {config_path=}. "
+                f"Original error:\n{str(e)}"
+            )
+
+        parallel_tasks_per_job = env.get(key, default)
+
+    return LocalBackendConfig(parallel_tasks_per_job=parallel_tasks_per_job)

--- a/fractal_server/app/runner/_local/_submit_setup.py
+++ b/fractal_server/app/runner/_local/_submit_setup.py
@@ -27,7 +27,24 @@ def _local_submit_setup(
     task_pars: Optional[TaskParameters] = None,
 ) -> dict[str, object]:
     """
-    FIXME
+    Collect WorfklowTask-specific configuration parameters from different
+    sources, and inject them for execution.
+
+    Arguments:
+        wftask:
+            WorkflowTask for which the configuration is to be assembled
+        task_pars:
+            Not used in this function.
+        workflow_dir:
+            Not used in this function.
+        workflow_dir_user:
+            Not used in this function.
+
+    Returns:
+        submit_setup_dict:
+            A dictionary that will be passed on to
+            `FractalThreadPoolExecutor.submit` and
+            `FractalThreadPoolExecutor.map`, so as to set extra options.
     """
 
     local_backend_config = get_local_backend_config(wftask=wftask)

--- a/fractal_server/app/runner/_local/_submit_setup.py
+++ b/fractal_server/app/runner/_local/_submit_setup.py
@@ -1,0 +1,35 @@
+# Copyright 2022 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Tommaso Comparin <tommaso.comparin@exact-lab.it>
+#
+# This file is part of Fractal and was originally developed by eXact lab S.r.l.
+# <exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+# Institute for Biomedical Research and Pelkmans Lab from the University of
+# Zurich.
+"""
+Submodule to define _local_submit_setup
+"""
+from pathlib import Path
+from typing import Optional
+
+from ...models import WorkflowTask
+from ..common import TaskParameters
+from ._local_config import get_local_backend_config
+
+
+def _local_submit_setup(
+    *,
+    wftask: WorkflowTask,
+    workflow_dir: Optional[Path] = None,
+    workflow_dir_user: Optional[Path] = None,
+    task_pars: Optional[TaskParameters] = None,
+) -> dict[str, object]:
+    """
+    FIXME
+    """
+
+    local_backend_config = get_local_backend_config(wftask=wftask)
+
+    return dict(local_backend_config=local_backend_config)

--- a/fractal_server/app/runner/_local/executor.py
+++ b/fractal_server/app/runner/_local/executor.py
@@ -1,5 +1,22 @@
+# Copyright 2022 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Tommaso Comparin <tommaso.comparin@exact-lab.it>
+#
+# This file is part of Fractal and was originally developed by eXact lab S.r.l.
+# <exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+# Institute for Biomedical Research and Pelkmans Lab from the University of
+# Zurich.
+"""
+Custom version of Python
+[ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)).
+"""
 from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+from typing import Iterable
 from typing import Optional
+from typing import Sequence
 
 from ._local_config import get_default_local_backend_config
 from ._local_config import LocalBackendConfig
@@ -7,7 +24,9 @@ from ._local_config import LocalBackendConfig
 
 class FractalThreadPoolExecutor(ThreadPoolExecutor):
     """
-    FIXME
+    Custom version of
+    [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor))
+    that overrides the `submit` and `map` methods
     """
 
     def submit(
@@ -16,47 +35,66 @@ class FractalThreadPoolExecutor(ThreadPoolExecutor):
         local_backend_config: Optional[LocalBackendConfig] = None,
         **kwargs,
     ):
+        """
+        Compared to the `ThreadPoolExecutor` method, here we accept an addition
+        keyword argument (`local_backend_config`), which is then simply
+        ignored.
+        """
         return super().submit(*args, **kwargs)
 
     def map(
         self,
-        fn,
-        *iterables,
+        fn: Callable,
+        *iterables: Sequence[Iterable],
         local_backend_config: Optional[LocalBackendConfig] = None,
     ):
         """
-        FIXME: docstring
+        Custom version of the `Executor.map` method
 
-        Changes from concurrent.futures interface:
-        * Remove timeout
-        * Remove chunksize
-        * All iterators are transformed into lists
+        The main change with the respect to the original `map` method is that
+        the list of tasks to be executed is split into chunks, and then
+        `super().map` is called (sequentially) on each chunk. The goal of this
+        change is to limit parallelism, e.g. due to limited computational
+        resources.
+
+        Other changes from the `concurrent.futures` `map` method:
+
+        1. Removed `timeout` argument;
+        2. Removed `chunksize`;
+        3. All iterators (both inputs and output ones) are transformed into
+           lists.
 
         Args:
-            fn: A callable that will take as many arguments as there are
-                passed iterables.
+            fn: A callable function.
+            iterables: The argument iterables (one iterable per argument of
+                       `fn`).
+           local_backend_config: The backend configuration, needed to extract
+                                 `parallel_tasks_per_job`.
         """
 
+        # Preliminary check
         iterable_lengths = [len(it) for it in iterables]
         if not len(set(iterable_lengths)) == 1:
             raise ValueError("Iterables have different lengths.")
-        n_elements = iterable_lengths[0]
 
+        # Set total number of arguments
+        n_elements = len(iterables[0])
+
+        # Set parallel_tasks_per_job
         if local_backend_config is None:
             local_backend_config = get_default_local_backend_config()
-
         parallel_tasks_per_job = local_backend_config.parallel_tasks_per_job
-
         if parallel_tasks_per_job is None:
             parallel_tasks_per_job = n_elements
 
+        # Execute tasks, in chunks of size parallel_tasks_per_job
         results = []
         for ind_chunk in range(0, n_elements, parallel_tasks_per_job):
-            chunked_iterables = [
+            chunk_iterables = [
                 it[ind_chunk : ind_chunk + parallel_tasks_per_job]  # noqa
                 for it in iterables
             ]
-            map_iter = super().map(fn, *chunked_iterables)
+            map_iter = super().map(fn, *chunk_iterables)
             results.extend(list(map_iter))
 
         return iter(results)

--- a/fractal_server/app/runner/_local/executor.py
+++ b/fractal_server/app/runner/_local/executor.py
@@ -1,0 +1,51 @@
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+from devtools import debug
+
+
+class FractalThreadPoolExecutor(ThreadPoolExecutor):
+    """
+    FIXME
+    """
+
+    def map(
+        self,
+        fn,
+        *iterables,
+        parallel_tasks_per_job: Optional[int] = None,
+    ):
+        """
+        FIXME: docstring
+
+        Changes from concurrent.futures interface:
+        * Remove timeout
+        * Remove chunksize
+        * All iterators are transformed into lists
+
+        Args:
+            fn: A callable that will take as many arguments as there are
+                passed iterables.
+        """
+
+        parallel_tasks_per_job = 1
+        debug(parallel_tasks_per_job)
+
+        iterable_lengths = [len(it) for it in iterables]
+        if not len(set(iterable_lengths)) == 1:
+            raise ValueError("Iterables have different lenghts.")
+        n_elements = iterable_lengths[0]
+
+        if parallel_tasks_per_job is None:
+            parallel_tasks_per_job = n_elements
+
+        results = []
+        for ind_chunk in range(0, n_elements, parallel_tasks_per_job):
+            chunked_iterables = [
+                it[ind_chunk : ind_chunk + parallel_tasks_per_job]  # noqa
+                for it in iterables
+            ]
+            map_iter = super().map(fn, *chunked_iterables)
+            results.extend(list(map_iter))
+
+        return iter(results)

--- a/fractal_server/app/runner/_local/executor.py
+++ b/fractal_server/app/runner/_local/executor.py
@@ -1,8 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
-from devtools import debug
-
 
 class FractalThreadPoolExecutor(ThreadPoolExecutor):
     """
@@ -27,9 +25,6 @@ class FractalThreadPoolExecutor(ThreadPoolExecutor):
             fn: A callable that will take as many arguments as there are
                 passed iterables.
         """
-
-        parallel_tasks_per_job = 1
-        debug(parallel_tasks_per_job)
 
         iterable_lengths = [len(it) for it in iterables]
         if not len(set(iterable_lengths)) == 1:

--- a/fractal_server/app/runner/_local/executor.py
+++ b/fractal_server/app/runner/_local/executor.py
@@ -1,17 +1,27 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
+from ._local_config import LocalBackendConfig
+
 
 class FractalThreadPoolExecutor(ThreadPoolExecutor):
     """
     FIXME
     """
 
+    def submit(
+        self,
+        *args,
+        local_backend_config: Optional[LocalBackendConfig] = None,
+        **kwargs,
+    ):
+        return super().submit(*args, **kwargs)
+
     def map(
         self,
         fn,
         *iterables,
-        parallel_tasks_per_job: Optional[int] = None,
+        local_backend_config: Optional[LocalBackendConfig] = None,
     ):
         """
         FIXME: docstring
@@ -28,8 +38,10 @@ class FractalThreadPoolExecutor(ThreadPoolExecutor):
 
         iterable_lengths = [len(it) for it in iterables]
         if not len(set(iterable_lengths)) == 1:
-            raise ValueError("Iterables have different lenghts.")
+            raise ValueError("Iterables have different lengths.")
         n_elements = iterable_lengths[0]
+
+        parallel_tasks_per_job = local_backend_config.parallel_tasks_per_job
 
         if parallel_tasks_per_job is None:
             parallel_tasks_per_job = n_elements

--- a/fractal_server/app/runner/_local/executor.py
+++ b/fractal_server/app/runner/_local/executor.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
+from ._local_config import get_default_local_backend_config
 from ._local_config import LocalBackendConfig
 
 
@@ -40,6 +41,9 @@ class FractalThreadPoolExecutor(ThreadPoolExecutor):
         if not len(set(iterable_lengths)) == 1:
             raise ValueError("Iterables have different lengths.")
         n_elements = iterable_lengths[0]
+
+        if local_backend_config is None:
+            local_backend_config = get_default_local_backend_config()
 
         parallel_tasks_per_job = local_backend_config.parallel_tasks_per_job
 

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -333,24 +333,6 @@ class Settings(BaseSettings):
         StrictSettings(**self.dict())
 
         # Check that some variables are allowed
-        if isinstance(self.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW, int):
-            if self.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW < 1:
-                raise FractalConfigurationError(
-                    f"{self.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW=} "
-                    "not allowed"
-                )
-
-        if (
-            self.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW
-            and self.FRACTAL_RUNNER_BACKEND != "local"
-        ):
-            logging.warning(
-                "FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW is set to "
-                f"{self.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW}, but "
-                f"FRACTAL_RUNNER_BACKEND={self.FRACTAL_RUNNER_BACKEND} is "
-                "the local backend."
-            )
-
         if self.FRACTAL_RUNNER_BACKEND == "slurm":
             info = f"FRACTAL_RUNNER_BACKEND={self.FRACTAL_RUNNER_BACKEND}"
 

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -333,6 +333,12 @@ class Settings(BaseSettings):
         StrictSettings(**self.dict())
 
         # Check that some variables are allowed
+        if self.FRACTAL_RUNNER_BACKEND not in ["local", "slurm"]:
+            raise FractalConfigurationError(
+                f"FRACTAL_RUNNER_BACKEND={self.FRACTAL_RUNNER_BACKEND}"
+                "is not allowed"
+            )
+
         if self.FRACTAL_RUNNER_BACKEND == "slurm":
             info = f"FRACTAL_RUNNER_BACKEND={self.FRACTAL_RUNNER_BACKEND}"
 

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -256,11 +256,6 @@ class Settings(BaseSettings):
     Path of JSON file with configuration for the SLURM backend.
     """
 
-    FRACTAL_RUNNER_DEFAULT_EXECUTOR: str = "cpu-low"
-    """
-    Used by some runner backends to configure the parameters to run jobs with.
-    """
-
     FRACTAL_SLURM_WORKER_PYTHON: Optional[str] = None
     """
     Path to Python interpreter that will run the jobs on the SLURM nodes. If

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -246,6 +246,11 @@ class Settings(BaseSettings):
     see details [here](../internals/logs/).
     """
 
+    FRACTAL_RUNNER_LOCAL_CONFIG_FILE: Optional[Path]
+    """
+    Path of JSON file with configuration for the local backend.
+    """
+
     FRACTAL_SLURM_CONFIG_FILE: Optional[Path]
     """
     Path of JSON file with configuration for the SLURM backend.

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -246,7 +246,7 @@ class Settings(BaseSettings):
     see details [here](../internals/logs/).
     """
 
-    FRACTAL_RUNNER_LOCAL_CONFIG_FILE: Optional[Path]
+    FRACTAL_LOCAL_CONFIG_FILE: Optional[Path]
     """
     Path of JSON file with configuration for the local backend.
     """

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -246,20 +246,6 @@ class Settings(BaseSettings):
     see details [here](../internals/logs/).
     """
 
-    FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW: Optional[int] = None
-    """
-    Maximum number of components that a parallel task may process
-    simultaneously, for the [local backend](../internals/runners/local/).  If
-    `None`, no limit is set.
-
-    Intended use case: Reduce memory requirements of a workflow by capping the
-    number of tasks running in parallel.
-
-    Note: this limit concerns a single task in a single workflow execution, but
-    it does **not** limit the global (i.e. across workflow executions) number
-    of components processed simultaneously.
-    """
-
     FRACTAL_SLURM_CONFIG_FILE: Optional[Path]
     """
     Path of JSON file with configuration for the SLURM backend.

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -13,7 +13,6 @@ Zurich.
 """
 import datetime
 import json
-from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from devtools import debug
@@ -26,6 +25,7 @@ from fractal_server.app.runner._common import _call_command_wrapper
 from fractal_server.app.runner._common import call_parallel_task
 from fractal_server.app.runner._common import call_single_task
 from fractal_server.app.runner._common import recursive_task_submission
+from fractal_server.app.runner._local.executor import FractalThreadPoolExecutor
 from fractal_server.app.runner.common import close_job_logger
 from fractal_server.app.runner.common import TaskParameters
 from fractal_server.logger import set_logger
@@ -34,7 +34,7 @@ from fractal_server.logger import set_logger
 async def test_command_wrapper(tmp_path):
     OUT_PATH = tmp_path / "out"
     ERR_PATH = tmp_path / "err"
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         future = executor.submit(
             _call_command_wrapper,
             f"ls -al {dummy_module.__file__}",
@@ -103,7 +103,7 @@ def test_recursive_task_submission_step0(tmp_path):
         metadata={},
     )
 
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         res = recursive_task_submission(
             executor=executor,
             task_list=task_list,
@@ -151,7 +151,7 @@ def test_recursive_parallel_task_submission_step0(tmp_path):
     debug(task_list)
     debug(task_pars)
 
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         res = recursive_task_submission(
             executor=executor,
             task_list=task_list,
@@ -217,7 +217,7 @@ def test_recursive_task_submission_inductive_step(tmp_path):
         metadata=METADATA_0,
     )
 
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         res = recursive_task_submission(
             executor=executor,
             task_list=task_list,
@@ -247,9 +247,12 @@ def test_call_parallel_task_max_tasks(
 ):
     """
     GIVEN A single task, parallelized over two components
-    WHEN This task is executed on a ThreadPoolExecutor via call_parallel_task
+    WHEN This task is executed on a FractalThreadPoolExecutor via
+        call_parallel_task
     THEN The FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW env variable is used
          correctly
+
+    FIXME THIS IS NOT UP TO DATE
     """
 
     # Reset environment variable
@@ -280,7 +283,7 @@ def test_call_parallel_task_max_tasks(
     debug(task_pars)
 
     # Execute task
-    with ThreadPoolExecutor() as executor:
+    with FractalThreadPoolExecutor() as executor:
         future_metadata = call_parallel_task(
             executor=executor,
             wftask=wftask,

--- a/tests/test_unit_fractal_thread_pool_executor.py
+++ b/tests/test_unit_fractal_thread_pool_executor.py
@@ -13,6 +13,7 @@ Zurich.
 import pytest
 from devtools import debug
 
+from fractal_server.app.runner._local._local_config import LocalBackendConfig
 from fractal_server.app.runner._local.executor import FractalThreadPoolExecutor
 
 
@@ -35,6 +36,9 @@ def test_executor_submit_with_exception():
 
 @pytest.mark.parametrize("parallel_tasks_per_job", [None, 1, 2, 3, 4, 8, 16])
 def test_executor_map(parallel_tasks_per_job: int):
+    local_backend_config = LocalBackendConfig(
+        parallel_tasks_per_job=parallel_tasks_per_job
+    )
 
     NUM = 7
 
@@ -48,7 +52,7 @@ def test_executor_map(parallel_tasks_per_job: int):
         result_generator = executor.map(
             fun_x,
             inputs,
-            parallel_tasks_per_job=parallel_tasks_per_job,
+            local_backend_config=local_backend_config,
         )
         results = list(result_generator)
         assert results == [fun_x(x) for x in inputs]
@@ -65,7 +69,7 @@ def test_executor_map(parallel_tasks_per_job: int):
             fun_xy,
             inputs_x,
             inputs_y,
-            parallel_tasks_per_job=parallel_tasks_per_job,
+            local_backend_config=local_backend_config,
         )
         results = list(result_generator)
         assert results == [fun_xy(x, y) for x, y in zip(inputs_x, inputs_y)]
@@ -79,10 +83,14 @@ def test_executor_map_with_exception(parallel_tasks_per_job):
         else:
             return n
 
+    local_backend_config = LocalBackendConfig(
+        parallel_tasks_per_job=parallel_tasks_per_job
+    )
+
     with pytest.raises(ValueError):
         with FractalThreadPoolExecutor() as executor:
             _ = executor.map(
                 _raise,
                 range(10),
-                parallel_tasks_per_job=parallel_tasks_per_job,
+                local_backend_config=local_backend_config,
             )

--- a/tests/test_unit_fractal_thread_pool_executor.py
+++ b/tests/test_unit_fractal_thread_pool_executor.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2022 (C) Friedrich Miescher Institute for Biomedical Research and
+University of Zurich
+
+Original author(s):
+Tommaso Comparin <tommaso.comparin@exact-lab.it>
+
+This file is part of Fractal and was originally developed by eXact lab S.r.l.
+<exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+Institute for Biomedical Research and Pelkmans Lab from the University of
+Zurich.
+"""
+import pytest
+from devtools import debug
+
+from fractal_server.app.runner._local.executor import FractalThreadPoolExecutor
+
+
+def test_executor_submit():
+    with FractalThreadPoolExecutor() as executor:
+        res = executor.submit(lambda: 42)
+    assert res.result() == 42
+
+
+def test_executor_submit_with_exception():
+    def raise_ValueError():
+        raise ValueError
+
+    with pytest.raises(ValueError) as e:
+        with FractalThreadPoolExecutor() as executor:
+            fut = executor.submit(raise_ValueError)
+            debug(fut.result())
+    debug(e.value)
+
+
+@pytest.mark.parametrize("parallel_tasks_per_job", [None, 1, 2, 3, 4, 8, 16])
+def test_executor_map(parallel_tasks_per_job: int):
+
+    NUM = 7
+
+    # Test function of a single variable
+    with FractalThreadPoolExecutor() as executor:
+
+        def fun_x(x):
+            return 3 * x + 1
+
+        inputs = list(range(NUM))
+        result_generator = executor.map(
+            fun_x,
+            inputs,
+            parallel_tasks_per_job=parallel_tasks_per_job,
+        )
+        results = list(result_generator)
+        assert results == [fun_x(x) for x in inputs]
+
+    # Test function of two variables
+    with FractalThreadPoolExecutor() as executor:
+
+        def fun_xy(x, y):
+            return 2 * x + y
+
+        inputs_x = list(range(3, 3 + NUM))
+        inputs_y = list(range(NUM))
+        result_generator = executor.map(
+            fun_xy,
+            inputs_x,
+            inputs_y,
+            parallel_tasks_per_job=parallel_tasks_per_job,
+        )
+        results = list(result_generator)
+        assert results == [fun_xy(x, y) for x, y in zip(inputs_x, inputs_y)]
+
+
+@pytest.mark.parametrize("parallel_tasks_per_job", [None, 1, 2, 4, 8, 16])
+def test_executor_map_with_exception(parallel_tasks_per_job):
+    def _raise(n: int):
+        if n == 5:
+            raise ValueError
+        else:
+            return n
+
+    with pytest.raises(ValueError):
+        with FractalThreadPoolExecutor() as executor:
+            _ = executor.map(
+                _raise,
+                range(10),
+                parallel_tasks_per_job=parallel_tasks_per_job,
+            )

--- a/tests/test_unit_fractal_thread_pool_executor.py
+++ b/tests/test_unit_fractal_thread_pool_executor.py
@@ -94,3 +94,17 @@ def test_executor_map_with_exception(parallel_tasks_per_job):
                 range(10),
                 local_backend_config=local_backend_config,
             )
+
+
+def test_executor_map_failure():
+    """
+    Iterables of different length -> ValueError
+    """
+
+    with pytest.raises(ValueError):
+        with FractalThreadPoolExecutor() as executor:
+            executor.map(
+                lambda x, y: 42,
+                [0, 1],
+                [2, 3, 4],
+            )

--- a/tests/test_unit_local_config.py
+++ b/tests/test_unit_local_config.py
@@ -1,0 +1,67 @@
+import json
+
+from devtools import debug
+
+from .fixtures_tasks import MockTask
+from .fixtures_tasks import MockWorkflowTask
+from fractal_server.app.runner._local._local_config import (
+    get_local_backend_config,
+)
+
+
+def test_get_local_backend_config(tmp_path):
+    """
+    Testing that:
+    1. WorkflowTask.meta overrides WorkflowTask.task.meta (this is taken care
+      of by the overridden_meta property);
+    2. WorkflowTask.task.meta overrides global config.
+    """
+
+    CONFIG_VALUE = 2
+    TASK_VALUE = 3
+    WFTASK_VALUE = 4
+
+    # Global configuration
+    config = dict(parallel_tasks_per_job=CONFIG_VALUE)
+    config_file = tmp_path / "config.json"
+    with config_file.open("w") as f:
+        json.dump(config, f)
+
+    # Case 1: no set value
+    mytask = MockTask(name="T", command="cmd", meta={})
+    mywftask = MockWorkflowTask(task=mytask, meta={})
+    debug(mywftask.overridden_meta)
+    local_backend_config = get_local_backend_config(wftask=mywftask)
+    assert local_backend_config.parallel_tasks_per_job is None
+
+    # Case 2: highest-priority set value is in config file
+    mytask = MockTask(name="T", command="cmd", meta={})
+    mywftask = MockWorkflowTask(task=mytask, meta={})
+    debug(mywftask.overridden_meta)
+    local_backend_config = get_local_backend_config(
+        wftask=mywftask,
+        config_path=config_file,
+    )
+    assert local_backend_config.parallel_tasks_per_job == CONFIG_VALUE
+
+    # Case 3: highest-priority set value is in Task
+    task_meta = dict(parallel_tasks_per_job=TASK_VALUE)
+    mytask = MockTask(name="T", command="cmd", meta=task_meta)
+    mywftask = MockWorkflowTask(task=mytask, meta={})
+    debug(mywftask.overridden_meta)
+    local_backend_config = get_local_backend_config(
+        wftask=mywftask,
+        config_path=config_file,
+    )
+    assert local_backend_config.parallel_tasks_per_job == TASK_VALUE
+
+    # Case 4: highest-priority set value is in WorfklowTask
+    wftask_meta = dict(parallel_tasks_per_job=WFTASK_VALUE)
+    mytask = MockTask(name="T", command="cmd", meta=task_meta)
+    mywftask = MockWorkflowTask(task=mytask, meta=wftask_meta)
+    debug(mywftask.overridden_meta)
+    local_backend_config = get_local_backend_config(
+        wftask=mywftask,
+        config_path=config_file,
+    )
+    assert local_backend_config.parallel_tasks_per_job == WFTASK_VALUE

--- a/tests/test_unit_settings.py
+++ b/tests/test_unit_settings.py
@@ -60,20 +60,7 @@ def test_FractalConfigurationError():
     debug(settings)
     settings.check()
 
-    settings.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW = None
-    debug(settings)
-    settings.check()
-
-    settings.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW = 1
-    debug(settings)
-    settings.check()
-
-    settings.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW = 0
-    debug(settings)
-    with pytest.raises(FractalConfigurationError):
-        settings.check()
-
-    settings.FRACTAL_LOCAL_RUNNER_MAX_TASKS_PER_WORKFLOW = -123
+    settings.FRACTAL_RUNNER_BACKEND = "invalid"
     debug(settings)
     with pytest.raises(FractalConfigurationError):
         settings.check()


### PR DESCRIPTION
From #598

- [x] Set up the logic to set the value of this variable for each workflow task, with the "usual" priority list (`WorkflowTask.meta` has priority over `WorkflowTask.task.meta`, which has priority over a global default).
- [x] Make sure that this WorkflowTask attribute is transferred to `ThreadPoolExecutor.map` (through the `submit_setup_call` function, as we do for the SLURM backend).
- [x] Subclass `ThreadPoolExecutor` into `FractalThreadPoolExecutor`, and override the `map` method with something similar to what we already do in the common runner part (i.e. running task in batches of a given size, and waiting for the end of a batch before processing a new one).
- [x] Remove `FRACTAL_RUNNER_MAX_TASKS_PER_WORKFLOW` from settings, and remove it from runner.
- [x] Adapt current test relying on `FRACTAL_RUNNER_MAX_TASKS_PER_WORKFLOW`
- [x] Write tests for the new executor
- [x] Add docs for the `local`-backend configuration.
- [x] Add tests for the `local`-backend configuration.

