### PR TITLE
Drop `WorkflowTask.arguments` property (close #741)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
     * Add `ApplyWorkflow.end_timestamp` column (\#687, \#684).
     * Prevent deletion of a `Workflow`/`Dataset` in relationship with existing `ApplyWorkflow` (\#703).
     * Add project-name uniqueness constraint in project-edit endpoint (\#689).
+* Other updates to internal logic:
+    * Drop `WorkflowTask.arguments` property and `WorkflowTask.assemble_args` method (\#742).
 * Expose `FRACTAL_CORS_ALLOW_ORIGIN` environment variable (\#688).
 * Package and repository:
     * Remove `fastapi-users-db-sqlmodel` dependency (\#660).

--- a/fractal_server/app/models/workflow.py
+++ b/fractal_server/app/models/workflow.py
@@ -39,8 +39,7 @@ class WorkflowTask(_WorkflowTaskBase, SQLModel, table=True):
         meta:
             Additional parameters useful for execution
         args:
-            Additional task arguments, overriding the ones in
-            `WorkflowTask.task.args`
+            Task arguments
         task:
             `Task` object associated with the current `WorkflowTask`
 
@@ -85,13 +84,6 @@ class WorkflowTask(_WorkflowTaskBase, SQLModel, table=True):
         return value
 
     @property
-    def arguments(self):
-        """
-        Transform args=None into {}
-        """
-        return self.args or {}
-
-    @property
     def is_parallel(self) -> bool:
         return self.task.is_parallel
 
@@ -108,21 +100,6 @@ class WorkflowTask(_WorkflowTaskBase, SQLModel, table=True):
         res = self.task.meta.copy() or {}
         res.update(self.meta or {})
         return res
-
-    def assemble_args(self, extra: dict[str, Any] = None) -> dict:
-        """
-        Merge of `extra` arguments and `self.arguments`.
-
-        Returns
-            full_args:
-                A dictionary consisting of the merge of `extra` and
-                `self.arguments`.
-        """
-        full_args = {}
-        if extra:
-            full_args.update(extra)
-        full_args.update(self.arguments)
-        return full_args
 
 
 class Workflow(_WorkflowBase, SQLModel, table=True):

--- a/fractal_server/app/runner/_common.py
+++ b/fractal_server/app/runner/_common.py
@@ -187,10 +187,10 @@ def call_single_task(
     Call a single task
 
     This assembles the runner arguments (input_paths, output_path, ...) and
-    task arguments (i.e., arguments that are specific to the task, such as
-    message or index in the dummy task), writes them to file, call the task
-    executable command passing the arguments file as an input and assembles
-    the output.
+    wftask arguments (i.e., arguments that are specific to the WorkflowTask,
+    such as message or index in the dummy task), writes them to file, call the
+    task executable command passing the arguments file as an input and
+    assembles the output.
 
     **Note**: This function is directly submitted to a
     `concurrent.futures`-compatible executor, as in
@@ -205,7 +205,7 @@ def call_single_task(
     Args:
         wftask:
             The workflow task to be called. This includes task specific
-            arguments via the task.task.arguments attribute.
+            arguments via the wftask.args attribute.
         task_pars:
             The parameters required to run the task which are not specific to
             the task, e.g., I/O paths.
@@ -238,11 +238,12 @@ def call_single_task(
         task_order=wftask.order,
     )
 
-    # assemble full args
-    args_dict = wftask.assemble_args(extra=task_pars.dict())
-
-    # write args file
-    write_args_file(args_dict, path=task_files.args)
+    # write args file (by assembling task_pars and wftask.args)
+    write_args_file(
+        task_pars.dict(),
+        wftask.args or {},
+        path=task_files.args,
+    )
 
     # assemble full command
     cmd = (
@@ -341,10 +342,10 @@ def call_single_parallel_task(
         component=component,
     )
 
-    # assemble full args
+    # write args file (by assembling task_pars, wftask.args and component)
     write_args_file(
         task_pars.dict(),
-        wftask.arguments,
+        wftask.args or {},
         dict(component=component),
         path=task_files.args,
     )

--- a/tests/fixtures_tasks.py
+++ b/tests/fixtures_tasks.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import Any
 from typing import Optional
 
 import pytest
@@ -42,22 +41,6 @@ class MockWorkflowTask(BaseModel):
         res = self.task.meta.copy() or {}
         res.update(self.meta or {})
         return res
-
-    def assemble_args(self, extra: dict[str, Any] = None):
-        """
-        Merge of `extra` arguments and `self.arguments`.
-
-        Return
-        ------
-        full_arsgs (dict):
-            A dictionary consisting of the merge of `extra` and
-            self.arguments.
-        """
-        full_args = {}
-        if extra:
-            full_args.update(extra)
-        full_args.update(self.arguments)
-        return full_args
 
 
 async def execute_command(cmd, **kwargs):

--- a/tests/fixtures_tasks.py
+++ b/tests/fixtures_tasks.py
@@ -20,7 +20,7 @@ class MockTask(BaseModel):
 class MockWorkflowTask(BaseModel):
     order: int = 0
     task: MockTask
-    arguments: dict = {}
+    args: dict = {}
     meta: dict = {}
     executor: Optional[str] = "default"
 

--- a/tests/test_backend_local.py
+++ b/tests/test_backend_local.py
@@ -51,7 +51,7 @@ async def test_command_wrapper(tmp_path):
 def test_call_single_task(tmp_path):
     wftask = MockWorkflowTask(
         task=MockTask(name="task0", command=f"python {dummy_module.__file__}"),
-        arguments=dict(message="test"),
+        args=dict(message="test"),
         order=0,
     )
     logger_name = "test_logger_call_single_task"
@@ -89,7 +89,7 @@ def test_recursive_task_submission_step0(tmp_path):
             task=MockTask(
                 name="task0", command=f"python {dummy_module.__file__}"
             ),
-            arguments=dict(message="test", index=INDEX),
+            args=dict(message="test", index=INDEX),
             order=0,
         )
     ]
@@ -133,7 +133,7 @@ def test_recursive_parallel_task_submission_step0(tmp_path):
                 command=f"python {dummy_parallel_module.__file__}",
                 parallelization_level="index",
             ),
-            arguments=dict(message=MESSAGE),
+            args=dict(message=MESSAGE),
             order=0,
         )
     ]
@@ -196,14 +196,14 @@ def test_recursive_task_submission_inductive_step(tmp_path):
             task=MockTask(
                 name=TASK_NAME, command=f"python {dummy_module.__file__}"
             ),
-            arguments=dict(message="test 0", index=0),
+            args=dict(message="test 0", index=0),
             order=0,
         ),
         MockWorkflowTask(
             task=MockTask(
                 name="task1", command=f"python {dummy_module.__file__}"
             ),
-            arguments=dict(message="test 1", index=1),
+            args=dict(message="test 1", index=1),
             order=1,
         ),
     ]
@@ -269,7 +269,7 @@ def test_call_parallel_task_max_tasks(
             command=f"python {dummy_parallel_module.__file__}",
             parallelization_level="index",
         ),
-        arguments=dict(message="message", sleep_time=SLEEP_TIME),
+        args=dict(message="message", sleep_time=SLEEP_TIME),
         order=0,
     )
     debug(wftask)

--- a/tests/test_unit_slurm_config.py
+++ b/tests/test_unit_slurm_config.py
@@ -92,7 +92,7 @@ def test_get_slurm_config(tmp_path, fail):
     )
     mywftask = MockWorkflowTask(
         task=mytask,
-        arguments=dict(message="test"),
+        args=dict(message="test"),
         order=0,
         meta=meta,
     )


### PR DESCRIPTION
1. Drop `WorkflowTask.arguments` property, and use `wftask.args or {}` when needed.
2. Drop `WorkflowTask.assemble_args` method, and set arguments of `write_args_file` correctly.
3. Improve docstrings.