### PR TITLE
Fix CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 1.3.2
 
-* Fix bug in job-stop endpoint, due to missing default for `FractalSlurmExecutor.wait_thread.shutdown_file` (\#768).
+* Fix bug in job-stop endpoint, due to missing default for `FractalSlurmExecutor.wait_thread.shutdown_file` (\#768, \#769).
 
 # 1.3.1
 

--- a/fractal_server/app/runner/_slurm/executor.py
+++ b/fractal_server/app/runner/_slurm/executor.py
@@ -225,8 +225,8 @@ class FractalSlurmExecutor(SlurmExecutor):
         self.wait_thread.slurm_poll_interval = slurm_poll_interval
         self.wait_thread.slurm_user = self.slurm_user
 
-        self.wait_thread.shutdown_file = shutdown_file or (
-            self.working_dir / SHUTDOWN_FILENAME
+        self.wait_thread.shutdown_file = (
+            shutdown_file or (self.working_dir / SHUTDOWN_FILENAME).as_posix()
         )
         self.wait_thread.shutdown_callback = self.shutdown
 


### PR DESCRIPTION
Likely related to `shutdown_file` updates (ref #766)

The failure happened on py39 (https://github.com/fractal-analytics-platform/fractal-server/actions/runs/5401580761/jobs/9811587799), but not on py310 (https://github.com/fractal-analytics-platform/fractal-server/actions/runs/5401580761/jobs/9811587979).