### PR TITLE
Fix bug in task insertion when `task.meta=None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Add sqlalchemy naming convention for DB constraints, and add `render_as_batch=True` to `do_run_migrations` (\#757).
 * Fix bug in job-stop endpoint, due to missing default for `FractalSlurmExecutor.wait_thread.shutdown_file` (\#768, \#769).
+* Fix bug upon inserting a task with `meta=None` into a Workflow (\#772).
 
 # 1.3.1
 

--- a/fractal_server/app/models/workflow.py
+++ b/fractal_server/app/models/workflow.py
@@ -152,7 +152,7 @@ class Workflow(_WorkflowBase, SQLModel, table=True):
             actual_args = None
 
         # Combine meta (higher priority) and db_task.meta (lower priority)
-        wt_meta = db_task.meta.copy() or {}
+        wt_meta = (db_task.meta or {}).copy()
         wt_meta.update(meta or {})
         if not wt_meta:
             wt_meta = None

--- a/tests/test_unit_db_models.py
+++ b/tests/test_unit_db_models.py
@@ -313,3 +313,18 @@ async def test_task_default_args_from_args_schema(
         )
         debug(task.default_args_from_args_schema)
         assert task.default_args_from_args_schema == {}
+
+
+async def test_insert_task_with_meta_none(
+    db, project_factory, MockCurrentUser, task_factory
+):
+    """
+    Test insertion of a task which has `task.meta=None`, see
+    https://github.com/fractal-analytics-platform/fractal-server/issues/770
+    """
+    async with MockCurrentUser(persist=True) as user:
+        project = await project_factory(user)
+        t0 = await task_factory(source="source0", meta=None)
+        wf = Workflow(name="my wfl", project_id=project.id)
+        args = dict(arg="test arg")
+        await wf.insert_task(t0.id, db=db, args=args)


### PR DESCRIPTION
Close  #770