### PR TITLE
Review checks for completed jobs in `FractalFileWaitThread.check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 **Note**: Numbers like (\#123) point to closed Pull Requests on the fractal-server repository.
 
-# Unreleased
+# 1.3.10
 
-* Update `fastapi` and `fastapi-users` to versions `^0.103.0` and `^12.1.0` respectively (\#877).
+* Updates to SLURM interface:
+    * Remove `sudo`-requiring `ls` calls from `FractalFileWaitThread.check` (\#885);
+    * Remove `FRACTAL_SLURM_KILLWAIT_INTERVAL` variable and corresponding logic (\#885);
+    * Remove `_multiple_paths_exist_as_user` helper function (\#885);
+    * Review type hints and default values of SLURM-related configuration variables (\#885).
+* Dependencies:
+    * Update `fastapi` to version `^0.103.0` (\#877);
+    * Update `fastapi-users` to version `^12.1.0` (\#877).
 
 # 1.3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Warning: updating to this version requires changes to the configuration variable
 
 * Updates to SLURM interface:
     * Remove `sudo`-requiring `ls` calls from `FractalFileWaitThread.check` (\#885);
+    * Change default of `FRACTAL_SLURM_POLL_INTERVAL` to 5 seconds (\#885);
+    * Rename `FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME` configuration variables into `FRACTAL_SLURM_ERROR_HANDLING_INTERVAL` (\#885);
     * Remove `FRACTAL_SLURM_KILLWAIT_INTERVAL` variable and corresponding logic (\#885);
     * Remove `_multiple_paths_exist_as_user` helper function (\#885);
-    * Renamed `FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME` configuration variables into `FRACTAL_SLURM_ERROR_HANDLING_INTERVAL`;
     * Review type hints and default values of SLURM-related configuration variables (\#885).
 * Dependencies:
     * Update `fastapi` to version `^0.103.0` (\#877);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 # 1.3.10
 
+Warning: updating to this version requires changes to the configuration variable
+
 * Updates to SLURM interface:
     * Remove `sudo`-requiring `ls` calls from `FractalFileWaitThread.check` (\#885);
     * Remove `FRACTAL_SLURM_KILLWAIT_INTERVAL` variable and corresponding logic (\#885);
     * Remove `_multiple_paths_exist_as_user` helper function (\#885);
+    * Renamed `FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME` configuration variables into `FRACTAL_SLURM_ERROR_HANDLING_INTERVAL`;
     * Review type hints and default values of SLURM-related configuration variables (\#885).
 * Dependencies:
     * Update `fastapi` to version `^0.103.0` (\#877);

--- a/fractal_server/app/runner/_slurm/_executor_wait_thread.py
+++ b/fractal_server/app/runner/_slurm/_executor_wait_thread.py
@@ -60,7 +60,7 @@ class FractalFileWaitThread(FileWaitThread):
         with self.lock:
             self.waiting[filenames] = jobid
 
-    def check_shutdown(self, i):
+    def check(self, i):
         """
         Do one shutdown-file-existence check.
 
@@ -96,7 +96,7 @@ class FractalFileWaitThread(FileWaitThread):
                 self.shutdown_callback()
                 return
             with self.lock:
-                self.check_shutdown(i)
+                self.check(i)
             time.sleep(self.interval)
 
 

--- a/fractal_server/app/runner/_slurm/_executor_wait_thread.py
+++ b/fractal_server/app/runner/_slurm/_executor_wait_thread.py
@@ -20,10 +20,10 @@ class FractalFileWaitThread(FileWaitThread):
 
     1. Each jobid in the waiting list is associated to a tuple of filenames,
        rather than a single one.
-    2. In the `check`, we skip checking for output-file existence (which would
-       require a `sudo -u user ls` call), and only check for the existence of
-       the shutdown file. All the logic to check whether a job is complete is
-       deferred to the `cfut.slurm.jobs_finished` function.
+    2. In the `check` method, we avoid output-file existence checks (which
+       would require `sudo -u user ls` calls), and we rather check for the
+       existence of the shutdown file. All the logic to check whether a job is
+       complete is deferred to the `cfut.slurm.jobs_finished` function.
     3. There are additional attributes (`slurm_user`, `shutdown_file` and
        `shutdown_callback`).
 

--- a/fractal_server/app/runner/_slurm/_slurm_config.py
+++ b/fractal_server/app/runner/_slurm/_slurm_config.py
@@ -24,7 +24,6 @@ from pydantic.error_wrappers import ValidationError
 
 from ....config import get_settings
 from ....logger import set_logger
-from ....logger import wrap_with_timing_logs
 from ....syringe import Inject
 from ...models import WorkflowTask
 
@@ -462,7 +461,6 @@ def get_default_slurm_config():
     )
 
 
-@wrap_with_timing_logs
 def get_slurm_config(
     wftask: WorkflowTask,
     workflow_dir: Path,

--- a/fractal_server/app/runner/_slurm/_subprocess_run_as_user.py
+++ b/fractal_server/app/runner/_slurm/_subprocess_run_as_user.py
@@ -18,7 +18,6 @@ another user. Note that this requires appropriate sudo permissions.
 import shlex
 import subprocess  # nosec
 from typing import Optional
-from typing import Sequence
 
 from ....logger import set_logger
 from ....logger import wrap_with_timing_logs
@@ -128,27 +127,6 @@ def _path_exists_as_user(*, path: str, user: Optional[str] = None) -> bool:
         user: If not `None`, user to be impersonated
     """
     res = _run_command_as_user(cmd=f"ls {path}", user=user)
-    if res.returncode == 0:
-        return True
-    else:
-        return False
-
-
-@wrap_with_timing_logs
-def _multiple_paths_exist_as_user(
-    *,
-    paths: Sequence[str],
-    user: Optional[str] = None,
-) -> bool:
-    """
-    Impersonate a user and check if some paths exists via `ls`
-
-    Arguments:
-        paths: Absolute file/folder path
-        user: If not `None`, user to be impersonated
-    """
-    paths_string = " ".join(paths)
-    res = _run_command_as_user(cmd=f"ls {paths_string}", user=user)
     if res.returncode == 0:
         return True
     else:

--- a/fractal_server/app/runner/_slurm/_subprocess_run_as_user.py
+++ b/fractal_server/app/runner/_slurm/_subprocess_run_as_user.py
@@ -20,12 +20,10 @@ import subprocess  # nosec
 from typing import Optional
 
 from ....logger import set_logger
-from ....logger import wrap_with_timing_logs
 
 logger = set_logger(__name__)
 
 
-@wrap_with_timing_logs
 def _run_command_as_user(
     *,
     cmd: str,
@@ -74,7 +72,6 @@ def _run_command_as_user(
     return res
 
 
-@wrap_with_timing_logs
 def _mkdir_as_user(*, folder: str, user: str) -> None:
     """
     Create a folder as a different user
@@ -94,7 +91,6 @@ def _mkdir_as_user(*, folder: str, user: str) -> None:
     _run_command_as_user(cmd=cmd, user=user, check=True)
 
 
-@wrap_with_timing_logs
 def _glob_as_user(
     *, folder: str, user: str, startswith: Optional[str] = None
 ) -> list[str]:
@@ -117,7 +113,6 @@ def _glob_as_user(
     return output
 
 
-@wrap_with_timing_logs
 def _path_exists_as_user(*, path: str, user: Optional[str] = None) -> bool:
     """
     Impersonate a user and check if `path` exists via `ls`

--- a/fractal_server/app/runner/_slurm/executor.py
+++ b/fractal_server/app/runner/_slurm/executor.py
@@ -725,7 +725,7 @@ class FractalSlurmExecutor(SlurmExecutor):
                 # missing
                 if not out_path.exists():
                     settings = Inject(get_settings)
-                    time.sleep(settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME)
+                    time.sleep(settings.FRACTAL_SLURM_ERROR_HANDLING_INTERVAL)
                 if not out_path.exists():
                     # Output pickle file is missing
                     info = (
@@ -742,8 +742,8 @@ class FractalSlurmExecutor(SlurmExecutor):
                         "(e.g. because there is not enough space on disk, or "
                         "due to an overloaded NFS filesystem). "
                         "Note that the server configuration has "
-                        "FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME="
-                        f"{settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME} "
+                        "FRACTAL_SLURM_ERROR_HANDLING_INTERVAL="
+                        f"{settings.FRACTAL_SLURM_ERROR_HANDLING_INTERVAL} "
                         "seconds.\n"
                     )
                     job_exc = self._prepare_JobExecutionError(jobid, info=info)

--- a/fractal_server/app/runner/_slurm/executor.py
+++ b/fractal_server/app/runner/_slurm/executor.py
@@ -638,8 +638,7 @@ class FractalSlurmExecutor(SlurmExecutor):
 
         Note: this function should be called after values in
         `self.map_jobid_to_slurm_files` have been updated, so that they point
-        to `self.working_dir` files which are readable for the user running
-        fractal-server.  by the server
+        to `self.working_dir` files which are readable from `fractal-server`.
 
         Arguments:
             jobid:

--- a/fractal_server/app/runner/_slurm/executor.py
+++ b/fractal_server/app/runner/_slurm/executor.py
@@ -629,25 +629,19 @@ class FractalSlurmExecutor(SlurmExecutor):
         self, jobid: str, info: str
     ) -> JobExecutionError:
         """
-        Prepare the JobExecutionError for a given job
+        Prepare the `JobExecutionError` for a given job
 
-            1. Wait for `FRACTAL_SLURM_KILLWAIT_INTERVAL` seconds, so that
-               SLURM has time to complete the job cancellation.
-            2. Assign the SLURM-related file names as attributes of the
-               JobExecutionError instance.
-
-        Note: this function should be called after values in
-        `self.map_jobid_to_slurm_files` have been updated, so that they point
-        to `self.working_dir` files which are readable from `fractal-server`.
+        This method creates a `JobExecutionError` object and sets its attribute
+        to the appropriate SLURM-related file names. Note that the method shoul
+        always be called after values in `self.map_jobid_to_slurm_files` have
+        been updated, so that they point to `self.working_dir` files which are
+        readable from `fractal-server`.
 
         Arguments:
             jobid:
                 ID of the SLURM job.
+            info:
         """
-        # Wait FRACTAL_SLURM_KILLWAIT_INTERVAL seconds
-        settings = Inject(get_settings)
-        settings.FRACTAL_SLURM_KILLWAIT_INTERVAL
-        time.sleep(settings.FRACTAL_SLURM_KILLWAIT_INTERVAL)
         # Extract SLURM file paths
         with self.jobs_lock:
             (

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -328,9 +328,10 @@ class Settings(BaseSettings):
     FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME: int = 5
     """
     Interval to wait (in seconds) when the SLURM backend does not find an
-    output pickle file, which could be for multiple reasons (the SLURM job was
-    cancelled, or writing the file is taking long). After this interval, the
-    file is considered as missing.
+    output pickle file - which could be due to several reasons (e.g. the SLURM
+    job was cancelled or failed, or writing the file is taking long). If the
+    file is still missing after this time interval, this leads to a
+    `JobExecutionError`.
     """
 
     FRACTAL_CORS_ALLOW_ORIGIN: str = (

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -318,7 +318,7 @@ class Settings(BaseSettings):
     not specified, the same interpreter that runs the server is used.
     """
 
-    FRACTAL_SLURM_POLL_INTERVAL: int = 60
+    FRACTAL_SLURM_POLL_INTERVAL: int = 5
     """
     Interval to wait (in seconds) before checking whether unfinished job are
     still running on SLURM (see `SlurmWaitThread` in

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -325,7 +325,7 @@ class Settings(BaseSettings):
     [`clusterfutures`](https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py)).
     """
 
-    FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME: int = 5
+    FRACTAL_SLURM_ERROR_HANDLING_INTERVAL: int = 5
     """
     Interval to wait (in seconds) when the SLURM backend does not find an
     output pickle file - which could be due to several reasons (e.g. the SLURM

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -322,8 +322,7 @@ class Settings(BaseSettings):
     """
     Interval to wait (in seconds) before checking whether unfinished job are
     still running on SLURM (see `SlurmWaitThread` in
-    [`clusterfutures`]
-    (https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py)).
+    [`clusterfutures`](https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py)).
     """
 
     FRACTAL_SLURM_KILLWAIT_INTERVAL: Optional[int] = 45

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -325,14 +325,6 @@ class Settings(BaseSettings):
     [`clusterfutures`](https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py)).
     """
 
-    FRACTAL_SLURM_KILLWAIT_INTERVAL: int = 45
-    """
-    Interval to wait (in seconds) when the execution of a SLURM-backend job
-    failed, before raising a `JobExecutionError`. Must be larger than [SLURM
-    `KillWait` timer](https://slurm.schedmd.com/slurm.conf.html#OPT_KillWait),
-    to make sure that stdout/stderr files have been written).
-    """
-
     FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME: int = 5
     """
     Interval to wait (in seconds) when the SLURM backend does not find an

--- a/fractal_server/config.py
+++ b/fractal_server/config.py
@@ -318,14 +318,14 @@ class Settings(BaseSettings):
     not specified, the same interpreter that runs the server is used.
     """
 
-    FRACTAL_SLURM_POLL_INTERVAL: Optional[int] = 60
+    FRACTAL_SLURM_POLL_INTERVAL: int = 60
     """
     Interval to wait (in seconds) before checking whether unfinished job are
     still running on SLURM (see `SlurmWaitThread` in
     [`clusterfutures`](https://github.com/sampsyo/clusterfutures/blob/master/cfut/__init__.py)).
     """
 
-    FRACTAL_SLURM_KILLWAIT_INTERVAL: Optional[int] = 45
+    FRACTAL_SLURM_KILLWAIT_INTERVAL: int = 45
     """
     Interval to wait (in seconds) when the execution of a SLURM-backend job
     failed, before raising a `JobExecutionError`. Must be larger than [SLURM
@@ -333,7 +333,7 @@ class Settings(BaseSettings):
     to make sure that stdout/stderr files have been written).
     """
 
-    FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME: Optional[int] = 4
+    FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME: int = 5
     """
     Interval to wait (in seconds) when the SLURM backend does not find an
     output pickle file, which could be for multiple reasons (the SLURM job was

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -116,8 +116,8 @@ def get_patched_settings(temp_path: Path):
 
     settings.FRACTAL_SLURM_CONFIG_FILE = temp_path / "slurm_config.json"
 
-    settings.FRACTAL_SLURM_POLL_INTERVAL = 4
-    settings.FRACTAL_SLURM_KILLWAIT_INTERVAL = 4
+    settings.FRACTAL_SLURM_POLL_INTERVAL = 2
+    settings.FRACTAL_SLURM_KILLWAIT_INTERVAL = 2
     settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME = 1
 
     settings.FRACTAL_LOGGING_LEVEL = logging.DEBUG

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -117,7 +117,7 @@ def get_patched_settings(temp_path: Path):
     settings.FRACTAL_SLURM_CONFIG_FILE = temp_path / "slurm_config.json"
 
     settings.FRACTAL_SLURM_POLL_INTERVAL = 1
-    settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME = 1
+    settings.FRACTAL_SLURM_ERROR_HANDLING_INTERVAL = 1
 
     settings.FRACTAL_LOGGING_LEVEL = logging.DEBUG
     return settings

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -116,8 +116,8 @@ def get_patched_settings(temp_path: Path):
 
     settings.FRACTAL_SLURM_CONFIG_FILE = temp_path / "slurm_config.json"
 
-    settings.FRACTAL_SLURM_POLL_INTERVAL = 2
-    settings.FRACTAL_SLURM_KILLWAIT_INTERVAL = 2
+    settings.FRACTAL_SLURM_POLL_INTERVAL = 1
+    settings.FRACTAL_SLURM_KILLWAIT_INTERVAL = 1
     settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME = 1
 
     settings.FRACTAL_LOGGING_LEVEL = logging.DEBUG

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -117,7 +117,6 @@ def get_patched_settings(temp_path: Path):
     settings.FRACTAL_SLURM_CONFIG_FILE = temp_path / "slurm_config.json"
 
     settings.FRACTAL_SLURM_POLL_INTERVAL = 1
-    settings.FRACTAL_SLURM_KILLWAIT_INTERVAL = 1
     settings.FRACTAL_SLURM_OUTPUT_FILE_GRACE_TIME = 1
 
     settings.FRACTAL_LOGGING_LEVEL = logging.DEBUG


### PR DESCRIPTION
(ref #884)

PRELIMINARY: With this change, the check of whether a job is complete (or failed) is fully deferred to the `jobs_finished` function (which only calls `squeue`, and then does not require `sudo`). We still rely on file-existence check to detect a shutdown event, but this does not require sudo.

## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
