### PR TITLE
Reduce project relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * Add script for adding `ApplyWorkflow.user_email` (\#1058).
     * Add `Dataset.project` and `Workflow.project` relationships (\#1082).
     * Avoid using `Project` relationships `dataset_list` or `workflow_list` within some `GET` endpoints (\#1082).
+    * Fully remove `Project` relationships `dataset_list`, `workflow_list` and `job_list` (\#1091).
 * Testing:
     * Only use ubuntu-22.04 in GitHub actions (\#1061).
     * Improve unit testing of database models (\#1082).

--- a/fractal_server/app/models/dataset.py
+++ b/fractal_server/app/models/dataset.py
@@ -39,7 +39,6 @@ class Dataset(_DatasetBase, SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     project_id: int = Field(foreign_key="project.id")
     project: "Project" = Relationship(  # noqa: F821
-        back_populates="dataset_list",
         sa_relationship_kwargs=dict(lazy="selectin"),
     )
 

--- a/fractal_server/app/models/project.py
+++ b/fractal_server/app/models/project.py
@@ -5,11 +5,8 @@ from sqlmodel import Relationship
 from sqlmodel import SQLModel
 
 from ..schemas.project import _ProjectBase
-from .dataset import Dataset
-from .job import ApplyWorkflow
 from .linkuserproject import LinkUserProject
 from .security import UserOAuth
-from .workflow import Workflow
 
 
 class Project(_ProjectBase, SQLModel, table=True):
@@ -21,24 +18,4 @@ class Project(_ProjectBase, SQLModel, table=True):
         sa_relationship_kwargs={
             "lazy": "selectin",
         },
-    )
-
-    dataset_list: list[Dataset] = Relationship(
-        sa_relationship_kwargs={
-            "lazy": "selectin",
-            "cascade": "all, delete-orphan",
-        },
-    )
-
-    workflow_list: list[Workflow] = Relationship(
-        sa_relationship_kwargs={
-            "lazy": "selectin",
-            "cascade": "all, delete-orphan",
-        },
-    )
-
-    job_list: list[ApplyWorkflow] = Relationship(
-        sa_relationship_kwargs={
-            "lazy": "selectin",
-        }
     )

--- a/fractal_server/app/models/workflow.py
+++ b/fractal_server/app/models/workflow.py
@@ -107,7 +107,6 @@ class Workflow(_WorkflowBase, SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     project_id: int = Field(foreign_key="project.id")
     project: "Project" = Relationship(  # noqa: F821
-        back_populates="workflow_list",
         sa_relationship_kwargs=dict(lazy="selectin"),
     )
 

--- a/fractal_server/app/routes/api/v1/job.py
+++ b/fractal_server/app/routes/api/v1/job.py
@@ -141,7 +141,12 @@ async def get_job_list(
     project = await _get_project_check_owner(
         project_id=project_id, user_id=user.id, db=db
     )
-    return project.job_list
+
+    stm = select(ApplyWorkflow).where(ApplyWorkflow.project_id == project.id)
+    res = await db.execute(stm)
+    job_list = res.scalars().all()
+
+    return job_list
 
 
 @router.get(

--- a/tests/fixtures_server.py
+++ b/tests/fixtures_server.py
@@ -388,7 +388,6 @@ async def dataset_factory(db: AsyncSession):
 
         _dataset = Dataset(**args)
         db.add(_dataset)
-        project.dataset_list.append(_dataset)
         db.add(project)
         await db.commit()
         await db.refresh(_dataset)
@@ -531,7 +530,6 @@ async def job_factory(db: AsyncSession):
         args.update(**kwargs)
         job = ApplyWorkflow(**args)
         db.add(job)
-        project.job_list.append(job)
         db.add(project)
         await db.commit()
         await db.refresh(job)
@@ -566,7 +564,6 @@ async def workflow_factory(db: AsyncSession):
 
         w = Workflow(**args)
         db.add(w)
-        project.workflow_list.append(w)
         db.add(project)
         await db.commit()
         await db.refresh(w)

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -216,11 +216,6 @@ async def test_delete_project(
         assert job.input_dataset_id == job.output_dataset_id == dataset_id
         assert job.workflow_id == wf.id
 
-        # Check that a project-related job exists - via relationship
-        project = await db.get(Project, project_id)
-        assert len(project.job_list) == 1
-        assert project.job_list[0].id == job.id
-
         # Delete the project
         res = await client.delete(f"{PREFIX}/project/{p['id']}/")
         assert res.status_code == 204

--- a/tests/test_unit_db_models.py
+++ b/tests/test_unit_db_models.py
@@ -203,52 +203,6 @@ async def test_cascade_delete_workflow(
         )
 
 
-async def test_cascade_delete_project(
-    db, client, MockCurrentUser, project_factory, task_factory
-):
-    """
-    GIVEN a Project
-    WHEN the Project is deleted
-    THEN all the related Workflows are deleted
-    """
-
-    async with MockCurrentUser(persist=True) as user:
-        project = await project_factory(user=user)
-        project_id = project.id
-
-        workflow1 = Workflow(
-            name="My first Workflow",
-            project_id=project.id,
-        )
-        workflow2 = Workflow(
-            name="My second Workflow",
-            project_id=project.id,
-        )
-        db.add(workflow1)
-        db.add(workflow2)
-        await db.commit()
-
-        await db.refresh(project)
-        await db.refresh(workflow1)
-        await db.refresh(workflow2)
-
-        before_delete_wf_ids = [wf.id for wf in project.workflow_list]
-
-        await db.delete(project)
-        await db.commit()
-
-        assert not await db.get(Project, project_id)
-
-        after_delete_wf_ids = (
-            (await db.execute(select(Workflow.id))).scalars().all()
-        )
-
-        debug(set(before_delete_wf_ids), set(after_delete_wf_ids))
-        assert not set(after_delete_wf_ids).intersection(
-            set(before_delete_wf_ids)
-        )
-
-
 async def test_state_table(db):
     """
     GIVEN the State table

--- a/tests/test_unit_db_models.py
+++ b/tests/test_unit_db_models.py
@@ -345,28 +345,10 @@ async def test_project_relationships(db):
     await db.commit()
 
     # Test relationships
-    await db.refresh(proj)
-    assert [wf.name for wf in proj.workflow_list] == ["wf1"]
-    assert [ds.name for ds in proj.dataset_list] == ["ds1"]
-    for wf in proj.workflow_list:
-        assert wf.project.name == "proj"
-    for ds in proj.dataset_list:
-        assert ds.project.name == "proj"
-
-    # Establish relationships via InstrumentedList's
-    proj.dataset_list.append(Dataset(name="ds2"))
-    proj.workflow_list.append(Workflow(name="wf2"))
-    await db.merge(proj)
-    await db.commit()
-
-    # Test relationships
-    await db.refresh(proj)
-    assert [wf.name for wf in proj.workflow_list] == ["wf1", "wf2"]
-    assert [ds.name for ds in proj.dataset_list] == ["ds1", "ds2"]
-    for wf in proj.workflow_list:
-        assert wf.project.name == "proj"
-    for ds in proj.dataset_list:
-        assert ds.project.name == "proj"
+    await db.refresh(wf1)
+    await db.refresh(ds1)
+    assert wf1.project.name == proj.name
+    assert ds1.project.name == proj.name
 
     # Establish relationships via {Dataset,Workflow}.project
     ds3 = Dataset(name="ds3", project=proj)
@@ -376,62 +358,7 @@ async def test_project_relationships(db):
     await db.commit()
 
     # Test relationships
-    await db.refresh(proj)
-    assert [wf.name for wf in proj.workflow_list] == ["wf1", "wf2", "wf3"]
-    assert [ds.name for ds in proj.dataset_list] == ["ds1", "ds2", "ds3"]
-    for wf in proj.workflow_list:
-        assert wf.project.name == "proj"
-    for ds in proj.dataset_list:
-        assert ds.project.name == "proj"
-
-    # Delete Workflow
-    await db.delete(wf3)
-    await db.commit()
-
-    # Test relationships
-    await db.refresh(proj)
-    assert [wf.name for wf in proj.workflow_list] == ["wf1", "wf2"]
-    assert [ds.name for ds in proj.dataset_list] == ["ds1", "ds2", "ds3"]
-    for wf in proj.workflow_list:
-        assert wf.project.name == "proj"
-    for ds in proj.dataset_list:
-        assert ds.project.name == "proj"
-
-    # Test that wf3 was deleted (while wf1 still exists)
-    stm = select(Workflow).where(Workflow.name == "wf3")
-    res = await db.execute(stm)
-    assert res.scalars().one_or_none() is None
-    stm = select(Workflow).where(Workflow.name == "wf1")
-    res = await db.execute(stm)
-    assert res.scalars().one_or_none() is not None
-
-    # Break relationship via InstrumentedList remove method
-    proj.workflow_list.remove(wf1)
-    await db.merge(proj)
-    await db.commit()
-
-    # Test relationships
-    await db.refresh(proj)
-    assert [wf.name for wf in proj.workflow_list] == ["wf2"]
-    assert [ds.name for ds in proj.dataset_list] == ["ds1", "ds2", "ds3"]
-    for wf in proj.workflow_list:
-        assert wf.project.name == "proj"
-    for ds in proj.dataset_list:
-        assert ds.project.name == "proj"
-
-    # Test that wf1 was deleted (while wf2 still exists)
-    stm = select(Workflow).where(Workflow.name == "wf1")
-    res = await db.execute(stm)
-    assert res.scalars().one_or_none() is None
-    stm = select(Workflow).where(Workflow.name == "wf2")
-    res = await db.execute(stm)
-    assert res.scalars().one_or_none() is not None
-
-    # Delete project
-    await db.delete(proj)
-
-    # Test that all datasets/workflows were deleted
-    res = await db.execute(select(Workflow))
-    assert res.scalars().one_or_none() is None
-    res = await db.execute(select(Dataset))
-    assert res.scalars().one_or_none() is None
+    await db.refresh(wf3)
+    await db.refresh(ds3)
+    assert wf3.project.name == proj.name
+    assert ds3.project.name == proj.name


### PR DESCRIPTION
By removing three nested relationships from `Project`, we hugely improve the performance bottleneck described in https://github.com/fractal-analytics-platform/fractal-web/issues/361.


## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
