### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -837,13 +837,13 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "griffe"
-version = "0.41.3"
+version = "0.42.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.41.3-py3-none-any.whl", hash = "sha256:27b4610f1ba6e5d039e9f0a2c97232e13463df75e53cb1833e0679f3377b9de2"},
-    {file = "griffe-0.41.3.tar.gz", hash = "sha256:9edcfa9f57f4d9c5fcc6d5ce067c67a685b7101a21a7d11848ce0437368e474c"},
+    {file = "griffe-0.42.0-py3-none-any.whl", hash = "sha256:384df6b802a60f70e65fdb7e83f5b27e2da869a12eac85b25b55250012dbc263"},
+    {file = "griffe-0.42.0.tar.gz", hash = "sha256:fb83ee602701ffdf99c9a6bf5f0a5a3bd877364b3bffb2c451dc8fbd9645b0cf"},
 ]
 
 [package.dependencies]
@@ -965,22 +965,22 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.1"
+version = "7.0.2"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
-    {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
+    {file = "importlib_metadata-7.0.2-py3-none-any.whl", hash = "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"},
+    {file = "importlib_metadata-7.0.2.tar.gz", hash = "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792"},
 ]
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 1 update, 0 removals

  • Updating griffe (0.41.3 -> 0.42.0)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
aiosqlite                    0.19.0    0.20.0       asyncio bridge to the st...
bcrypt                       4.0.1     4.1.2        Modern password hashing ...
bumpver                      2022.1120 2023.1129    Bump version numbers in ...
cloudpickle                  2.2.1     3.0.0        Extended pickling suppor...
coverage                     6.5.0     7.4.3        Code coverage measuremen...
fastapi                      0.109.2   0.110.0      FastAPI framework, high ...
fastapi-users                12.1.3    13.0.0       Ready-to-use and customi...
griffe                       0.41.3    0.42.0       Signatures for entire Py...
httpcore                     0.16.3    1.0.4        A minimal low-level HTTP...
httpx                        0.23.3    0.27.0       The next generation HTTP...
mkdocs                       1.5.2     1.5.3        Project documentation wi...
mkdocs-gen-files             0.4.0     0.5.0        MkDocs plugin to program...
mkdocs-literate-nav          0.5.0     0.6.1        MkDocs plugin to specify...
mkdocs-material              9.1.21    9.5.13       Documentation that simpl...
mkdocs-render-swagger-plugin 0.1.0     0.1.1        MKDocs plugin for render...
mkdocs-section-index         0.3.5     0.3.8        MkDocs plugin to allow c...
mkdocstrings                 0.22.0    0.24.1       Automatic documentation ...
mypy                         0.982     1.9.0        Optional static typing f...
packaging                    23.2      24.0         Core utilities for Pytho...
pre-commit                   2.21.0    3.6.2        A framework for managing...
pydantic                     1.10.14   2.6.3        Data validation and sett...
pytest                       7.4.4     8.1.1        pytest: simple powerful ...
pytest-asyncio               0.21.1    0.23.5.post1 Pytest support for asyncio
pytest-docker                2.2.0     3.1.1        Simple pytest fixtures f...
python-dotenv                0.21.1    1.0.1        Read key-value pairs fro...
python-multipart             0.0.7     0.0.9        A streaming multipart pa...
rfc3986                      1.5.0     2.0.0        Validating URI Reference...
sqlmodel                     0.0.14    0.0.16       SQLModel, SQL databases ...
starlette                    0.36.3    0.37.2       The little ASGI library ...
uvicorn                      0.27.1    0.28.0       The lightning-fast ASGI ...
```

### Outdated dependencies _after_ PR:

```bash
aiosqlite                    0.19.0    0.20.0       asyncio bridge to the st...
bcrypt                       4.0.1     4.1.2        Modern password hashing ...
bumpver                      2022.1120 2023.1129    Bump version numbers in ...
cloudpickle                  2.2.1     3.0.0        Extended pickling suppor...
coverage                     6.5.0     7.4.3        Code coverage measuremen...
fastapi                      0.109.2   0.110.0      FastAPI framework, high ...
fastapi-users                12.1.3    13.0.0       Ready-to-use and customi...
httpcore                     0.16.3    1.0.4        A minimal low-level HTTP...
httpx                        0.23.3    0.27.0       The next generation HTTP...
mkdocs                       1.5.2     1.5.3        Project documentation wi...
mkdocs-gen-files             0.4.0     0.5.0        MkDocs plugin to program...
mkdocs-literate-nav          0.5.0     0.6.1        MkDocs plugin to specify...
mkdocs-material              9.1.21    9.5.13       Documentation that simpl...
mkdocs-render-swagger-plugin 0.1.0     0.1.1        MKDocs plugin for render...
mkdocs-section-index         0.3.5     0.3.8        MkDocs plugin to allow c...
mkdocstrings                 0.22.0    0.24.1       Automatic documentation ...
mypy                         0.982     1.9.0        Optional static typing f...
packaging                    23.2      24.0         Core utilities for Pytho...
pre-commit                   2.21.0    3.6.2        A framework for managing...
pydantic                     1.10.14   2.6.3        Data validation and sett...
pytest                       7.4.4     8.1.1        pytest: simple powerful ...
pytest-asyncio               0.21.1    0.23.5.post1 Pytest support for asyncio
pytest-docker                2.2.0     3.1.1        Simple pytest fixtures f...
python-dotenv                0.21.1    1.0.1        Read key-value pairs fro...
python-multipart             0.0.7     0.0.9        A streaming multipart pa...
rfc3986                      1.5.0     2.0.0        Validating URI Reference...
sqlmodel                     0.0.14    0.0.16       SQLModel, SQL databases ...
starlette                    0.36.3    0.37.2       The little ASGI library ...
uvicorn                      0.27.1    0.28.0       The lightning-fast ASGI ...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._