### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "a2wsgi"
-version = "1.10.2"
+version = "1.10.4"
 description = "Convert WSGI app to ASGI app or ASGI app to WSGI app."
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "a2wsgi-1.10.2-py3-none-any.whl", hash = "sha256:d29b91d9b18c9308c65e26e0e2bd0cd6af8135ced2bc1d2d03a2b18cc4e32f0c"},
-    {file = "a2wsgi-1.10.2.tar.gz", hash = "sha256:46b2ca427cf9ad538c145e32eb36857e1cbf477b72fe1ed0e3d35e98c06061b9"},
+    {file = "a2wsgi-1.10.4-py3-none-any.whl", hash = "sha256:f17da93bf5952e0b0938c87f261c52b7305ddfab1ff3c70dd10b4b76db3851d3"},
+    {file = "a2wsgi-1.10.4.tar.gz", hash = "sha256:50e81ac55aa609fa2c666e42bacc25c424c8884ce6072f1a7e902114b7ee5d63"},
 ]
 
 [[package]]
@@ -1053,13 +1053,13 @@ testing = ["pytest"]
 
 [[package]]
 name = "markdown"
-version = "3.5.2"
+version = "3.6"
 description = "Python implementation of John Gruber's Markdown."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Markdown-3.5.2-py3-none-any.whl", hash = "sha256:d43323865d89fc0cb9b20c75fc8ad313af307cc087e84b657d9eec768eddeadd"},
-    {file = "Markdown-3.5.2.tar.gz", hash = "sha256:e1ac7b3dc550ee80e602e71c1d168002f062e49f1b11e26a36264dafd4df2ef8"},
+    {file = "Markdown-3.6-py3-none-any.whl", hash = "sha256:48f276f4d8cfb8ce6527c8f79e2ee29708508bf4d40aa410fbc3b4ee832c850f"},
+    {file = "Markdown-3.6.tar.gz", hash = "sha256:ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224"},
 ]
 
 [package.dependencies]
@@ -2041,18 +2041,18 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "setuptools"
-version = "69.1.1"
+version = "69.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.1.1-py3-none-any.whl", hash = "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56"},
-    {file = "setuptools-69.1.1.tar.gz", hash = "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"},
+    {file = "setuptools-69.2.0-py3-none-any.whl", hash = "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c"},
+    {file = "setuptools-69.2.0.tar.gz", hash = "sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -2329,18 +2329,18 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "zipp"
-version = "3.17.0"
+version = "3.18.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
-    {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},
+    {file = "zipp-3.18.1-py3-none-any.whl", hash = "sha256:206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b"},
+    {file = "zipp-3.18.1.tar.gz", hash = "sha256:2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [extras]
 gunicorn = ["gunicorn"]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 3 updates, 0 removals

  • Updating markdown (3.5.2 -> 3.6)
  • Updating setuptools (69.1.1 -> 69.2.0)
  • Updating a2wsgi (1.10.2 -> 1.10.4)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
a2wsgi                       1.10.2    1.10.4    Convert WSGI app to ASGI ap...
aiosqlite                    0.19.0    0.20.0    asyncio bridge to the stand...
bcrypt                       4.0.1     4.1.2     Modern password hashing for...
bumpver                      2022.1120 2023.1129 Bump version numbers in pro...
cloudpickle                  2.2.1     3.0.0     Extended pickling support f...
coverage                     6.5.0     7.4.4     Code coverage measurement f...
fastapi                      0.109.2   0.110.0   FastAPI framework, high per...
fastapi-users                12.1.3    13.0.0    Ready-to-use and customizab...
httpcore                     0.16.3    1.0.4     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.0    The next generation HTTP cl...
markdown                     3.5.2     3.6       Python implementation of Jo...
mkdocs                       1.5.2     1.5.3     Project documentation with ...
mkdocs-gen-files             0.4.0     0.5.0     MkDocs plugin to programmat...
mkdocs-literate-nav          0.5.0     0.6.1     MkDocs plugin to specify th...
mkdocs-material              9.1.21    9.5.14    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.0     0.1.1     MKDocs plugin for rendering...
mkdocs-section-index         0.3.5     0.3.8     MkDocs plugin to allow clic...
mkdocstrings                 0.22.0    0.24.1    Automatic documentation fro...
mkdocstrings-python          1.8.0     1.9.0     A Python handler for mkdocs...
mypy                         0.982     1.9.0     Optional static typing for ...
packaging                    23.2      24.0      Core utilities for Python p...
pre-commit                   2.21.0    3.6.2     A framework for managing an...
pydantic                     1.10.14   2.6.4     Data validation and setting...
pytest                       7.4.4     8.1.1     pytest: simple powerful tes...
pytest-asyncio               0.21.1    0.23.6    Pytest support for asyncio
pytest-docker                2.2.0     3.1.1     Simple pytest fixtures for ...
python-dotenv                0.21.1    1.0.1     Read key-value pairs from a...
python-multipart             0.0.7     0.0.9     A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
setuptools                   69.1.1    69.2.0    Easily download, build, ins...
sqlmodel                     0.0.14    0.0.16    SQLModel, SQL databases in ...
starlette                    0.36.3    0.37.2    The little ASGI library tha...
uvicorn                      0.27.1    0.28.1    The lightning-fast ASGI ser...
```

### Outdated dependencies _after_ PR:

```bash
aiosqlite                    0.19.0    0.20.0    asyncio bridge to the stand...
bcrypt                       4.0.1     4.1.2     Modern password hashing for...
bumpver                      2022.1120 2023.1129 Bump version numbers in pro...
cloudpickle                  2.2.1     3.0.0     Extended pickling support f...
coverage                     6.5.0     7.4.4     Code coverage measurement f...
fastapi                      0.109.2   0.110.0   FastAPI framework, high per...
fastapi-users                12.1.3    13.0.0    Ready-to-use and customizab...
httpcore                     0.16.3    1.0.4     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.0    The next generation HTTP cl...
mkdocs                       1.5.2     1.5.3     Project documentation with ...
mkdocs-gen-files             0.4.0     0.5.0     MkDocs plugin to programmat...
mkdocs-literate-nav          0.5.0     0.6.1     MkDocs plugin to specify th...
mkdocs-material              9.1.21    9.5.14    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.0     0.1.1     MKDocs plugin for rendering...
mkdocs-section-index         0.3.5     0.3.8     MkDocs plugin to allow clic...
mkdocstrings                 0.22.0    0.24.1    Automatic documentation fro...
mkdocstrings-python          1.8.0     1.9.0     A Python handler for mkdocs...
mypy                         0.982     1.9.0     Optional static typing for ...
packaging                    23.2      24.0      Core utilities for Python p...
pre-commit                   2.21.0    3.6.2     A framework for managing an...
pydantic                     1.10.14   2.6.4     Data validation and setting...
pytest                       7.4.4     8.1.1     pytest: simple powerful tes...
pytest-asyncio               0.21.1    0.23.6    Pytest support for asyncio
pytest-docker                2.2.0     3.1.1     Simple pytest fixtures for ...
python-dotenv                0.21.1    1.0.1     Read key-value pairs from a...
python-multipart             0.0.7     0.0.9     A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
sqlmodel                     0.0.14    0.0.16    SQLModel, SQL databases in ...
starlette                    0.36.3    0.37.2    The little ASGI library tha...
uvicorn                      0.27.1    0.28.1    The lightning-fast ASGI ser...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._