### PR TITLE
Exclude dataset `history` from `applyworkflow` (close #1450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 * API:
     * Fix bug in status endpoint (\#1449).
     * Improve handling of out-of-scope scenario in status endpoint (\#1449).
+    * Do not include dataset `history` and `images` in `JobV2.dataset_dump` (\#1445).
     * Forbid extra arguments in `DumpV2` schemas (\#1445).
+* API V1:
+    * Do not include dataset `history` in `ApplyWorkflow.{input,output}_dataset_dump` (\#1450).
 * Move settings logs to `check_settings` and use fractal-server `set_logger` (\#1452).
 * Benchmarks:
     * Handle some more errors in benchmark flow (\#1445).

--- a/fractal_server/app/routes/api/v1/project.py
+++ b/fractal_server/app/routes/api/v1/project.py
@@ -398,7 +398,7 @@ async def apply_workflow(
         user_email=user.email,
         input_dataset_dump=dict(
             **input_dataset.model_dump(
-                exclude={"resource_list", "timestamp_created"}
+                exclude={"resource_list", "history" "timestamp_created"}
             ),
             timestamp_created=_encode_as_utc(input_dataset.timestamp_created),
             resource_list=[
@@ -408,7 +408,7 @@ async def apply_workflow(
         ),
         output_dataset_dump=dict(
             **output_dataset.model_dump(
-                exclude={"resource_list", "timestamp_created"}
+                exclude={"resource_list", "history", "timestamp_created"}
             ),
             timestamp_created=_encode_as_utc(output_dataset.timestamp_created),
             resource_list=[


### PR DESCRIPTION
This concerns `input_dataset_dump` and `output_dataset_dump` attributes

## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
- [ ] I merged `main` into the current branch.
