### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -204,6 +204,17 @@ files = [
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
+name = "backports-strenum"
+version = "1.3.1"
+description = "Base class for creating enumerated constants that are also subclasses of str"
+optional = false
+python-versions = ">=3.8.6,<3.11"
+files = [
+    {file = "backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83"},
+    {file = "backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414"},
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.0.1"
 description = "Modern password hashing for your software and your servers"
@@ -707,13 +718,13 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -904,16 +915,17 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "griffe"
-version = "0.47.0"
+version = "0.48.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.47.0-py3-none-any.whl", hash = "sha256:07a2fd6a8c3d21d0bbb0decf701d62042ccc8a576645c7f8799fe1f10de2b2de"},
-    {file = "griffe-0.47.0.tar.gz", hash = "sha256:95119a440a3c932b13293538bdbc405bee4c36428547553dc6b327e7e7d35e5a"},
+    {file = "griffe-0.48.0-py3-none-any.whl", hash = "sha256:f944c6ff7bd31cf76f264adcd6ab8f3d00a2f972ae5cc8db2d7b6dcffeff65a2"},
+    {file = "griffe-0.48.0.tar.gz", hash = "sha256:f099461c02f016b6be4af386d5aa92b01fb4efe6c1c2c360dda9a5d0a863bb7f"},
 ]
 
 [package.dependencies]
+backports-strenum = {version = ">=1.3", markers = "python_version < \"3.11\""}
 colorama = ">=0.4"
 
 [[package]]
@@ -994,13 +1006,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "httpx-oauth"
-version = "0.14.1"
+version = "0.15.0"
 description = "Async OAuth client using HTTPX"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx_oauth-0.14.1-py3-none-any.whl", hash = "sha256:3ccf35760d157a9abbf4a78024b744b5532ec5d4d03fc1db3e71123ce9d33e32"},
-    {file = "httpx_oauth-0.14.1.tar.gz", hash = "sha256:e58c60bce99568b4e98ce88abf0e2111a9b6c7f79c29bea88cc89d9edb78dfbc"},
+    {file = "httpx_oauth-0.15.0-py3-none-any.whl", hash = "sha256:39ac91b2b98b8bf97176bc55a70a77cb9cff6cb3a964d2abb1b1256f901aa8ef"},
+    {file = "httpx_oauth-0.15.0.tar.gz", hash = "sha256:b4bb1115d7f18fd88718feb70767d6badc72891afee2d32d2af7a1d9395a11f7"},
 ]
 
 [package.dependencies]
@@ -1102,13 +1114,13 @@ files = [
 
 [[package]]
 name = "makefun"
-version = "1.15.3"
+version = "1.15.4"
 description = "Small library to dynamically create python functions."
 optional = false
 python-versions = "*"
 files = [
-    {file = "makefun-1.15.3-py2.py3-none-any.whl", hash = "sha256:2d692b46c284db54a54897fa3df3b2443b39eb6711bd7c7d2149322bffca0cc3"},
-    {file = "makefun-1.15.3.tar.gz", hash = "sha256:72039743135dd44ba5037d08e9c6fe4b29dfee7f2eb8106951f9a20ca7d6d1fa"},
+    {file = "makefun-1.15.4-py2.py3-none-any.whl", hash = "sha256:945d078a7e01a903f2cbef738b33e0ebc52b8d35fb7e20c528ed87b5c80db5b7"},
+    {file = "makefun-1.15.4.tar.gz", hash = "sha256:9f9b9904e7c397759374a88f4c57781fbab2a458dec78df4b3ee6272cd9fb010"},
 ]
 
 [[package]]
@@ -2228,13 +2240,13 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "setuptools"
-version = "70.2.0"
+version = "70.3.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
-    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
+    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
+    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
 ]
 
 [package.extras]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 1 install, 5 updates, 0 removals

  - Updating exceptiongroup (1.2.1 -> 1.2.2)
  - Installing backports-strenum (1.3.1)
  - Updating griffe (0.47.0 -> 0.48.0)
  - Updating httpx-oauth (0.14.1 -> 0.15.0)
  - Updating makefun (1.15.3 -> 1.15.4)
  - Updating setuptools (70.2.0 -> 70.3.0)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
aiosqlite                    0.19.0    0.20.0    asyncio bridge to the stand...
bcrypt                       4.0.1     4.1.3     Modern password hashing for...
bumpver                      2022.1120 2023.1129 Bump version numbers in pro...
coverage                     7.5.4     7.6.0     Code coverage measurement f...
email-validator              2.1.2     2.2.0     A robust email address synt...
exceptiongroup               1.2.1     1.2.2     Backport of PEP 654 (except...
fastapi                      0.110.3   0.111.1   FastAPI framework, high per...
fastapi-users                12.1.3    13.0.0    Ready-to-use and customizab...
griffe                       0.47.0    0.48.0    Signatures for entire Pytho...
httpcore                     0.16.3    1.0.5     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.0    The next generation HTTP cl...
httpx-oauth                  0.14.1    0.15.0    Async OAuth client using HTTPX
makefun                      1.15.3    1.15.4    Small library to dynamicall...
mkdocs                       1.5.3     1.6.0     Project documentation with ...
mkdocs-material              9.5.17    9.5.29    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.24.3    0.25.1    Automatic documentation fro...
mkdocstrings-python          1.10.0    1.10.5    A Python handler for mkdocs...
packaging                    23.2      24.1      Core utilities for Python p...
pre-commit                   2.21.0    3.7.1     A framework for managing an...
psutil                       5.9.8     6.0.0     Cross-platform lib for proc...
pydantic                     1.10.17   2.8.2     Data validation and setting...
pytest                       8.1.2     8.2.2     pytest: simple powerful tes...
python-multipart             0.0.7     0.0.9     A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
setuptools                   70.2.0    70.3.0    Easily download, build, ins...
uvicorn                      0.29.0    0.30.1    The lightning-fast ASGI ser...
```

### Outdated dependencies _after_ PR:

```bash
aiosqlite                    0.19.0    0.20.0    asyncio bridge to the stand...
bcrypt                       4.0.1     4.1.3     Modern password hashing for...
bumpver                      2022.1120 2023.1129 Bump version numbers in pro...
coverage                     7.5.4     7.6.0     Code coverage measurement f...
email-validator              2.1.2     2.2.0     A robust email address synt...
fastapi                      0.110.3   0.111.1   FastAPI framework, high per...
fastapi-users                12.1.3    13.0.0    Ready-to-use and customizab...
httpcore                     0.16.3    1.0.5     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.0    The next generation HTTP cl...
mkdocs                       1.5.3     1.6.0     Project documentation with ...
mkdocs-material              9.5.17    9.5.29    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.24.3    0.25.1    Automatic documentation fro...
mkdocstrings-python          1.10.0    1.10.5    A Python handler for mkdocs...
packaging                    23.2      24.1      Core utilities for Python p...
pre-commit                   2.21.0    3.7.1     A framework for managing an...
psutil                       5.9.8     6.0.0     Cross-platform lib for proc...
pydantic                     1.10.17   2.8.2     Data validation and setting...
pytest                       8.1.2     8.2.2     pytest: simple powerful tes...
python-multipart             0.0.7     0.0.9     A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
uvicorn                      0.29.0    0.30.1    The lightning-fast ASGI ser...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._