### PR TITLE
Allow setting `UserSettings` nullable attributes to `None` in PATCH endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 **Note**: Numbers like (\#1234) point to closed Pull Requests on the fractal-server repository.
 
+# Unreleased
+
+* Allow setting `UserSettings.cache_dir=None` in PATCH endpoint (\#1814).
+
 # 2.6.1
 
 * DB:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-* Allow setting `UserSettings.cache_dir=None` in PATCH endpoint (\#1814).
+* Allow setting `UserSettings` attributes to `None` in standard/strict PATCH endpoints (\#1814).
 
 # 2.6.1
 

--- a/fractal_server/app/schemas/_validators.py
+++ b/fractal_server/app/schemas/_validators.py
@@ -69,14 +69,19 @@ def valint(attribute: str, min_val: int = 1):
     return val
 
 
-def val_absolute_path(attribute: str):
+def val_absolute_path(attribute: str, accept_none: bool = False):
     """
     Check that a string attribute is an absolute path
     """
 
     def val(string: Optional[str]) -> str:
         if string is None:
-            raise ValueError(f"String attribute '{attribute}' cannot be None")
+            if accept_none:
+                return string
+            else:
+                raise ValueError(
+                    f"String attribute '{attribute}' cannot be None"
+                )
         s = string.strip()
         if not s:
             raise ValueError(f"String attribute '{attribute}' cannot be empty")

--- a/fractal_server/app/schemas/user_settings.py
+++ b/fractal_server/app/schemas/user_settings.py
@@ -47,23 +47,25 @@ class UserSettingsUpdate(BaseModel, extra=Extra.forbid):
     slurm_accounts: Optional[list[StrictStr]] = None
     cache_dir: Optional[str] = None
 
-    _ssh_host = validator("ssh_host", allow_reuse=True)(valstr("ssh_host"))
+    _ssh_host = validator("ssh_host", allow_reuse=True)(
+        valstr("ssh_host", accept_none=True)
+    )
     _ssh_username = validator("ssh_username", allow_reuse=True)(
-        valstr("ssh_username")
+        valstr("ssh_username", accept_none=True)
     )
     _ssh_private_key_path = validator(
         "ssh_private_key_path", allow_reuse=True
-    )(val_absolute_path("ssh_private_key_path"))
+    )(val_absolute_path("ssh_private_key_path", accept_none=True))
 
     _ssh_tasks_dir = validator("ssh_tasks_dir", allow_reuse=True)(
-        val_absolute_path("ssh_tasks_dir")
+        val_absolute_path("ssh_tasks_dir", accept_none=True)
     )
     _ssh_jobs_dir = validator("ssh_jobs_dir", allow_reuse=True)(
-        val_absolute_path("ssh_jobs_dir")
+        val_absolute_path("ssh_jobs_dir", accept_none=True)
     )
 
     _slurm_user = validator("slurm_user", allow_reuse=True)(
-        valstr("slurm_user")
+        valstr("slurm_user", accept_none=True)
     )
 
     @validator("slurm_accounts")
@@ -76,6 +78,8 @@ class UserSettingsUpdate(BaseModel, extra=Extra.forbid):
 
     @validator("cache_dir")
     def cache_dir_validator(cls, value):
+        if value is None:
+            return None
         validate_cmd(value)
         return val_absolute_path("cache_dir")(value)
 
@@ -90,5 +94,7 @@ class UserSettingsUpdateStrict(BaseModel, extra=Extra.forbid):
 
     @validator("cache_dir")
     def cache_dir_validator(cls, value):
+        if value is None:
+            return value
         validate_cmd(value)
         return val_absolute_path("cache_dir")(value)

--- a/tests/no_version/test_unit_schemas_no_version.py
+++ b/tests/no_version/test_unit_schemas_no_version.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
+from fractal_server.app.schemas._validators import val_absolute_path
 from fractal_server.app.schemas.user import UserCreate
 from fractal_server.app.schemas.user_group import UserGroupCreate
 from fractal_server.app.schemas.user_group import UserGroupRead
@@ -133,3 +134,18 @@ def test_user_settings_update():
         assert getattr(update_request_body, key) is None
         assert key in update_request_body.dict(exclude_unset=True)
         assert key not in update_request_body.dict(exclude_none=True)
+
+
+def test_unit_val_absolute_path():
+    val_absolute_path("this_attr")("/path")
+    val_absolute_path("this_attr", accept_none=False)("/path")
+    val_absolute_path("this_attr", accept_none=True)("/path")
+
+    with pytest.raises(ValueError):
+        val_absolute_path("this_attr")(None)
+    with pytest.raises(ValueError):
+        val_absolute_path("this_attr", accept_none=False)(None)
+    val_absolute_path("this_attr", accept_none=True)(None)
+
+    with pytest.raises(ValueError):
+        val_absolute_path("this_attr")("non/absolute/path")

--- a/tests/no_version/test_unit_schemas_no_version.py
+++ b/tests/no_version/test_unit_schemas_no_version.py
@@ -83,6 +83,10 @@ def test_user_settings_update():
     update = UserSettingsUpdate(ssh_host="NEW_HOST", slurm_accounts=None)
     assert update.slurm_accounts is None
 
+    update = UserSettingsUpdateStrict(cache_dir=None)
+    assert update.cache_dir is None
+    assert "cache_dir" in update.dict(exclude_unset=True).keys()
+
     with pytest.raises(ValidationError):
         UserSettingsUpdate(slurm_accounts=[""])
     with pytest.raises(ValidationError):

--- a/tests/no_version/test_unit_schemas_no_version.py
+++ b/tests/no_version/test_unit_schemas_no_version.py
@@ -77,15 +77,22 @@ def test_user_settings_read():
 
 
 def test_user_settings_update():
-    update = UserSettingsUpdate(ssh_host="NEW_HOST")
-    assert update.slurm_accounts is None
 
-    update = UserSettingsUpdate(ssh_host="NEW_HOST", slurm_accounts=None)
-    assert update.slurm_accounts is None
+    update_request_body = UserSettingsUpdate(ssh_host="NEW_HOST")
+    assert update_request_body.slurm_accounts is None
 
-    update = UserSettingsUpdateStrict(cache_dir=None)
-    assert update.cache_dir is None
-    assert "cache_dir" in update.dict(exclude_unset=True).keys()
+    update_request_body = UserSettingsUpdate(
+        ssh_host="NEW_HOST", slurm_accounts=None
+    )
+    assert update_request_body.slurm_accounts is None
+
+    update_request_body = UserSettingsUpdate(cache_dir=None)
+    assert update_request_body.cache_dir is None
+    assert "cache_dir" in update_request_body.dict(exclude_unset=True).keys()
+
+    update_request_body = UserSettingsUpdateStrict(cache_dir=None)
+    assert update_request_body.cache_dir is None
+    assert "cache_dir" in update_request_body.dict(exclude_unset=True).keys()
 
     with pytest.raises(ValidationError):
         UserSettingsUpdate(slurm_accounts=[""])
@@ -101,3 +108,28 @@ def test_user_settings_update():
         UserSettingsUpdateStrict(ssh_host="NEW_HOST")
     with pytest.raises(ValidationError):
         UserSettingsUpdateStrict(slurm_user="NEW_SLURM_USER")
+
+    # Verify that a series of attributes can be made None
+    nullable_attributes = [
+        "ssh_host",
+        "ssh_username",
+        "ssh_private_key_path",
+        "ssh_tasks_dir",
+        "ssh_jobs_dir",
+        "slurm_user",
+        "cache_dir",
+    ]
+    nullable_attributes_strict = [
+        "cache_dir",
+    ]
+    for key in nullable_attributes:
+        update_request_body = UserSettingsUpdate(**{key: None})
+        assert getattr(update_request_body, key) is None
+        assert key in update_request_body.dict(exclude_unset=True)
+        assert key not in update_request_body.dict(exclude_none=True)
+
+    for key in nullable_attributes_strict:
+        update_request_body = UserSettingsUpdateStrict(**{key: None})
+        assert getattr(update_request_body, key) is None
+        assert key in update_request_body.dict(exclude_unset=True)
+        assert key not in update_request_body.dict(exclude_none=True)


### PR DESCRIPTION
## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
- [ ] I added logging to new code - if appropriate.
- [x] I merged `main` into the current branch.
