### PR TITLE
Add `task_group_activity_id` query parameter to `GET  /activity/`

### DIFF
--- a/fractal_server/app/routes/admin/v2/task_group.py
+++ b/fractal_server/app/routes/admin/v2/task_group.py
@@ -35,6 +35,7 @@ logger = set_logger(__name__)
 
 @router.get("/activity/", response_model=list[TaskGroupActivityV2Read])
 async def get_task_group_activity_list(
+    task_group_activity_id: Optional[int] = None,
     user_id: Optional[int] = None,
     taskgroupv2_id: Optional[int] = None,
     pkg_name: Optional[str] = None,
@@ -46,6 +47,8 @@ async def get_task_group_activity_list(
 ) -> list[TaskGroupActivityV2Read]:
 
     stm = select(TaskGroupActivityV2)
+    if task_group_activity_id is not None:
+        stm = stm.where(TaskGroupActivityV2.id == task_group_activity_id)
     if user_id:
         stm = stm.where(TaskGroupActivityV2.user_id == user_id)
     if taskgroupv2_id:

--- a/fractal_server/app/routes/api/v2/task_group.py
+++ b/fractal_server/app/routes/api/v2/task_group.py
@@ -37,6 +37,7 @@ logger = set_logger(__name__)
 
 @router.get("/activity/", response_model=list[TaskGroupActivityV2Read])
 async def get_task_group_activity_list(
+    task_group_activity_id: Optional[int] = None,
     taskgroupv2_id: Optional[int] = None,
     pkg_name: Optional[str] = None,
     status: Optional[TaskGroupActivityStatusV2] = None,
@@ -49,6 +50,8 @@ async def get_task_group_activity_list(
     stm = select(TaskGroupActivityV2).where(
         TaskGroupActivityV2.user_id == user.id
     )
+    if task_group_activity_id is not None:
+        stm = stm.where(TaskGroupActivityV2.id == task_group_activity_id)
     if taskgroupv2_id is not None:
         stm = stm.where(TaskGroupActivityV2.taskgroupv2_id == taskgroupv2_id)
     if pkg_name is not None:

--- a/tests/v2/03_api/test_api_admin.py
+++ b/tests/v2/03_api/test_api_admin.py
@@ -910,6 +910,12 @@ async def test_get_task_group_activity(
             f"{PREFIX}/task-group/activity/?user_id={user2.id}"
         )
         assert len(res.json()) == 2
+        # task_group_activity_id
+        res = await client.get(
+            f"{PREFIX}/task-group/activity/"
+            f"?user_id={user1.id}&task_group_activity_id={activity1.id}"
+        )
+        assert len(res.json()) == 1
         # taskgroupv2_id
         res = await client.get(
             f"{PREFIX}/task-group/activity/"

--- a/tests/v2/03_api/test_api_task_group.py
+++ b/tests/v2/03_api/test_api_task_group.py
@@ -348,6 +348,13 @@ async def test_get_task_group_activity_list(
             f"{PREFIX}/activity/?taskgroupv2_id={task.taskgroupv2_id}"
         )
         assert len(res.json()) == 2
+        # task_group_activity_id
+        res = await client.get(
+            f"{PREFIX}/activity/"
+            f"?taskgroupv2_id={task.taskgroupv2_id}"
+            f"&task_group_activity_id={activity3.id}"
+        )
+        assert len(res.json()) == 1
         # pkg_name
         res = await client.get(f"{PREFIX}/activity/?pkg_name=foo")
         assert len(res.json()) == 3


### PR DESCRIPTION
closes #2021 

## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
- [ ] I added logging to new code - if appropriate.
- [ ] I merged `main` into the current branch.
