### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -570,20 +570,20 @@ files = [
 
 [[package]]
 name = "deprecated"
-version = "1.2.14"
+version = "1.2.15"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 files = [
-    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
-    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
+    {file = "Deprecated-1.2.15-py2.py3-none-any.whl", hash = "sha256:353bc4a8ac4bfc96800ddab349d89c25dec1079f65fd53acdcc1e0b975b21320"},
+    {file = "deprecated-1.2.15.tar.gz", hash = "sha256:683e561a90de76239796e6b6feac66b99030d2dd3fcf61ef996330f14bbb9b0d"},
 ]
 
 [package.dependencies]
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
+dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "jinja2 (>=3.0.3,<3.1.0)", "setuptools", "sphinx (<2)", "tox"]
 
 [[package]]
 name = "devtools"
@@ -697,13 +697,13 @@ pytest = ["pytest (>=7)"]
 
 [[package]]
 name = "fastapi"
-version = "0.115.4"
+version = "0.115.5"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fastapi-0.115.4-py3-none-any.whl", hash = "sha256:0b504a063ffb3cf96a5e27dc1bc32c80ca743a2528574f9cdc77daa2d31b4742"},
-    {file = "fastapi-0.115.4.tar.gz", hash = "sha256:db653475586b091cb8b2fec2ac54a680ac6a158e07406e1abae31679e8826349"},
+    {file = "fastapi-0.115.5-py3-none-any.whl", hash = "sha256:596b95adbe1474da47049e802f9a65ab2ffa9c2b07e7efee70eb8a66c9f2f796"},
+    {file = "fastapi-0.115.5.tar.gz", hash = "sha256:0e7a4d0dc0d01c68df21887cce0945e72d3c48b9f4f79dfe7a7d53aa08fbb289"},
 ]
 
 [package.dependencies]
@@ -2183,13 +2183,13 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "setuptools"
-version = "75.4.0"
+version = "75.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "setuptools-75.4.0-py3-none-any.whl", hash = "sha256:b3c5d862f98500b06ffdf7cc4499b48c46c317d8d56cb30b5c8bce4d88f5c216"},
-    {file = "setuptools-75.4.0.tar.gz", hash = "sha256:1dc484f5cf56fd3fe7216d7b8df820802e7246cfb534a1db2aa64f14fcb9cdcb"},
+    {file = "setuptools-75.5.0-py3-none-any.whl", hash = "sha256:87cb777c3b96d638ca02031192d40390e0ad97737e27b6b4fa831bea86f2f829"},
+    {file = "setuptools-75.5.0.tar.gz", hash = "sha256:5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef"},
 ]
 
 [package.extras]
@@ -2335,13 +2335,13 @@ SQLAlchemy = ">=2.0.14,<2.1.0"
 
 [[package]]
 name = "starlette"
-version = "0.41.2"
+version = "0.41.3"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.41.2-py3-none-any.whl", hash = "sha256:fbc189474b4731cf30fcef52f18a8d070e3f3b46c6a04c97579e85e6ffca942d"},
-    {file = "starlette-0.41.2.tar.gz", hash = "sha256:9834fd799d1a87fd346deb76158668cfa0b0d56f85caefe8268e2d97c3468b62"},
+    {file = "starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7"},
+    {file = "starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 4 updates, 0 removals

  - Updating starlette (0.41.2 -> 0.41.3)
  - Updating deprecated (1.2.14 -> 1.2.15)
  - Updating fastapi (0.115.4 -> 0.115.5)
  - Updating setuptools (75.4.0 -> 75.5.0)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
bcrypt                       4.0.1     4.2.0     Modern password hashing for...
bumpver                      2022.1120 2024.1130 Bump version numbers in pro...
cloudpickle                  3.0.0     3.1.0     Pickler class to extend the...
coverage                     7.5.4     7.6.7     Code coverage measurement f...
deprecated                   1.2.14    1.2.15    Python @deprecated decorato...
email-validator              2.1.2     2.2.0     A robust email address synt...
fastapi                      0.115.4   0.115.5   FastAPI framework, high per...
fastapi-users                12.1.3    14.0.0    Ready-to-use and customizab...
gunicorn                     22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpcore                     0.16.3    1.0.7     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.2    The next generation HTTP cl...
mkdocs                       1.5.3     1.6.1     Project documentation with ...
mkdocs-material              9.5.17    9.5.44    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.25.2    0.27.0    Automatic documentation fro...
mkdocstrings-python          1.10.9    1.12.2    A Python handler for mkdocs...
packaging                    23.2      24.2      Core utilities for Python p...
pre-commit                   2.21.0    4.0.1     A framework for managing an...
psutil                       5.9.8     6.1.0     Cross-platform lib for proc...
pydantic                     1.10.19   2.9.2     Data validation and setting...
pyjwt                        2.8.0     2.10.0    JSON Web Token implementati...
pytest                       8.1.2     8.3.3     pytest: simple powerful tes...
pytest-asyncio               0.23.8    0.24.0    Pytest support for asyncio
python-multipart             0.0.7     0.0.17    A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
setuptools                   75.4.0    75.5.0    Easily download, build, ins...
sqlmodel                     0.0.21    0.0.22    SQLModel, SQL databases in ...
starlette                    0.41.2    0.41.3    The little ASGI library tha...
uvicorn                      0.29.0    0.32.0    The lightning-fast ASGI ser...
```

### Outdated dependencies _after_ PR:

```bash
bcrypt                       4.0.1     4.2.0     Modern password hashing for...
bumpver                      2022.1120 2024.1130 Bump version numbers in pro...
cloudpickle                  3.0.0     3.1.0     Pickler class to extend the...
coverage                     7.5.4     7.6.7     Code coverage measurement f...
email-validator              2.1.2     2.2.0     A robust email address synt...
fastapi-users                12.1.3    14.0.0    Ready-to-use and customizab...
gunicorn                     22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpcore                     0.16.3    1.0.7     A minimal low-level HTTP cl...
httpx                        0.23.3    0.27.2    The next generation HTTP cl...
mkdocs                       1.5.3     1.6.1     Project documentation with ...
mkdocs-material              9.5.17    9.5.44    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.25.2    0.27.0    Automatic documentation fro...
mkdocstrings-python          1.10.9    1.12.2    A Python handler for mkdocs...
packaging                    23.2      24.2      Core utilities for Python p...
pre-commit                   2.21.0    4.0.1     A framework for managing an...
psutil                       5.9.8     6.1.0     Cross-platform lib for proc...
pydantic                     1.10.19   2.9.2     Data validation and setting...
pyjwt                        2.8.0     2.10.0    JSON Web Token implementati...
pytest                       8.1.2     8.3.3     pytest: simple powerful tes...
pytest-asyncio               0.23.8    0.24.0    Pytest support for asyncio
python-multipart             0.0.7     0.0.17    A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
sqlmodel                     0.0.21    0.0.22    SQLModel, SQL databases in ...
uvicorn                      0.29.0    0.32.0    The lightning-fast ASGI ser...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._