### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,24 +35,24 @@ tz = ["backports.zoneinfo"]
 
 [[package]]
 name = "anyio"
-version = "4.6.2.post1"
+version = "4.7.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
-    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+    {file = "anyio-4.7.0-py3-none-any.whl", hash = "sha256:ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352"},
+    {file = "anyio-4.7.0.tar.gz", hash = "sha256:2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48"},
 ]
 
 [package.dependencies]
 exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -760,13 +760,13 @@ pytest = ["pytest (>=7)"]
 
 [[package]]
 name = "fastapi"
-version = "0.115.5"
+version = "0.115.6"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fastapi-0.115.5-py3-none-any.whl", hash = "sha256:596b95adbe1474da47049e802f9a65ab2ffa9c2b07e7efee70eb8a66c9f2f796"},
-    {file = "fastapi-0.115.5.tar.gz", hash = "sha256:0e7a4d0dc0d01c68df21887cce0945e72d3c48b9f4f79dfe7a7d53aa08fbb289"},
+    {file = "fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305"},
+    {file = "fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654"},
 ]
 
 [package.dependencies]
@@ -1015,17 +1015,17 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "httpx-oauth"
-version = "0.15.1"
+version = "0.16.0"
 description = "Async OAuth client using HTTPX"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "httpx_oauth-0.15.1-py3-none-any.whl", hash = "sha256:89b45f250e93e42bbe9631adf349cab0e3d3ced958c07e06651735198d1bdf00"},
-    {file = "httpx_oauth-0.15.1.tar.gz", hash = "sha256:4094cf0938fc7252b5f5dfd62cd1ab5aee2fcb6734e621942ee17d1af4806b74"},
+    {file = "httpx_oauth-0.16.0-py3-none-any.whl", hash = "sha256:4394a5e60cb66fd6e14031d41be8e4060580c553422a641b624ade0f33d0df04"},
+    {file = "httpx_oauth-0.16.0.tar.gz", hash = "sha256:5ce4696e4c9572711fb558808f7436afd7712db825c56b0f4f430e16c649f136"},
 ]
 
 [package.dependencies]
-httpx = ">=0.18,<1.0.0"
+httpx = ">=0.18,<0.28"
 
 [[package]]
 name = "identify"
@@ -1118,13 +1118,13 @@ files = [
 
 [[package]]
 name = "mako"
-version = "1.3.6"
+version = "1.3.8"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Mako-1.3.6-py3-none-any.whl", hash = "sha256:a91198468092a2f1a0de86ca92690fb0cfc43ca90ee17e15d93662b4c04b241a"},
-    {file = "mako-1.3.6.tar.gz", hash = "sha256:9ec3a1583713479fae654f83ed9fa8c9a4c16b7bb0daba0e6bbebff50c0d983d"},
+    {file = "Mako-1.3.8-py3-none-any.whl", hash = "sha256:42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627"},
+    {file = "mako-1.3.8.tar.gz", hash = "sha256:577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"},
 ]
 
 [package.dependencies]
@@ -2262,13 +2262,13 @@ type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (>=1.12
 
 [[package]]
 name = "six"
-version = "1.16.0"
+version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 5 updates, 0 removals

  - Updating six (1.16.0 -> 1.17.0)
  - Updating anyio (4.6.2.post1 -> 4.7.0)
  - Updating fastapi (0.115.5 -> 0.115.6)
  - Updating httpx-oauth (0.15.1 -> 0.16.0)
  - Updating mako (1.3.6 -> 1.3.8)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
anyio                        4.6.2.post1 4.7.0     High level compatibility ...
asttokens                    2.4.1       3.0.0     Annotate AST trees with s...
bumpver                      2022.1120   2024.1130 Bump version numbers in p...
cloudpickle                  3.0.0       3.1.0     Pickler class to extend t...
coverage                     7.5.4       7.6.9     Code coverage measurement...
fastapi                      0.115.5     0.115.6   FastAPI framework, high p...
gunicorn                     22.0.0      23.0.0    WSGI HTTP Server for UNIX
httpcore                     0.16.3      1.0.7     A minimal low-level HTTP ...
httpx                        0.23.3      0.28.1    The next generation HTTP ...
httpx-oauth                  0.15.1      0.16.0    Async OAuth client using ...
mako                         1.3.6       1.3.8     A super-fast templating l...
mkdocs                       1.5.3       1.6.1     Project documentation wit...
mkdocs-material              9.5.17      9.5.48    Documentation that simply...
mkdocs-render-swagger-plugin 0.1.1       0.1.2     MKDocs plugin for renderi...
mkdocs-section-index         0.3.8       0.3.9     MkDocs plugin to allow cl...
mkdocstrings                 0.25.2      0.27.0    Automatic documentation f...
mkdocstrings-python          1.10.9      1.12.2    A Python handler for mkdo...
packaging                    23.2        24.2      Core utilities for Python...
pre-commit                   2.21.0      4.0.1     A framework for managing ...
psutil                       5.9.8       6.1.0     Cross-platform lib for pr...
pydantic                     1.10.19     2.10.3    Data validation and setti...
pyjwt                        2.9.0       2.10.1    JSON Web Token implementa...
pytest                       8.1.2       8.3.4     pytest: simple powerful t...
pytest-asyncio               0.23.8      0.24.0    Pytest support for asyncio
python-multipart             0.0.17      0.0.19    A streaming multipart par...
rfc3986                      1.5.0       2.0.0     Validating URI References...
six                          1.16.0      1.17.0    Python 2 and 3 compatibil...
sqlmodel                     0.0.21      0.0.22    SQLModel, SQL databases i...
uvicorn                      0.29.0      0.32.1    The lightning-fast ASGI s...
```

### Outdated dependencies _after_ PR:

```bash
asttokens                    2.4.1     3.0.0     Annotate AST trees with sou...
bumpver                      2022.1120 2024.1130 Bump version numbers in pro...
cloudpickle                  3.0.0     3.1.0     Pickler class to extend the...
coverage                     7.5.4     7.6.9     Code coverage measurement f...
gunicorn                     22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpcore                     0.16.3    1.0.7     A minimal low-level HTTP cl...
httpx                        0.23.3    0.28.1    The next generation HTTP cl...
mkdocs                       1.5.3     1.6.1     Project documentation with ...
mkdocs-material              9.5.17    9.5.48    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.25.2    0.27.0    Automatic documentation fro...
mkdocstrings-python          1.10.9    1.12.2    A Python handler for mkdocs...
packaging                    23.2      24.2      Core utilities for Python p...
pre-commit                   2.21.0    4.0.1     A framework for managing an...
psutil                       5.9.8     6.1.0     Cross-platform lib for proc...
pydantic                     1.10.19   2.10.3    Data validation and setting...
pyjwt                        2.9.0     2.10.1    JSON Web Token implementati...
pytest                       8.1.2     8.3.4     pytest: simple powerful tes...
pytest-asyncio               0.23.8    0.24.0    Pytest support for asyncio
python-multipart             0.0.17    0.0.19    A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
sqlmodel                     0.0.21    0.0.22    SQLModel, SQL databases in ...
uvicorn                      0.29.0    0.32.1    The lightning-fast ASGI ser...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._