### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -146,19 +146,19 @@ test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
 
 [[package]]
 name = "attrs"
-version = "24.2.0"
+version = "24.3.0"
 description = "Classes Without Boilerplate"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
-    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
+    {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
+    {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
 ]
 
 [package.extras]
 benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
@@ -236,13 +236,13 @@ toml = "*"
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
-    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
+    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
+    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
 ]
 
 [[package]]
@@ -582,7 +582,6 @@ files = [
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb"},
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b"},
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385"},
     {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e"},
     {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e"},
     {file = "cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053"},
@@ -593,7 +592,6 @@ files = [
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289"},
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7"},
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba"},
     {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64"},
     {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285"},
     {file = "cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417"},


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 2 updates, 0 removals

  - Updating certifi (2024.8.30 -> 2024.12.14)
  - Updating attrs (24.2.0 -> 24.3.0)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
asttokens                    2.4.1     3.0.0      Annotate AST trees with so...
attrs                        24.2.0    24.3.0     Classes Without Boilerplate
bumpver                      2022.1120 2024.1130  Bump version numbers in pr...
certifi                      2024.8.30 2024.12.14 Python package for providi...
cloudpickle                  3.0.0     3.1.0      Pickler class to extend th...
coverage                     7.5.4     7.6.9      Code coverage measurement ...
gunicorn                     22.0.0    23.0.0     WSGI HTTP Server for UNIX
httpcore                     0.16.3    1.0.7      A minimal low-level HTTP c...
httpx                        0.23.3    0.28.1     The next generation HTTP c...
mkdocs                       1.5.3     1.6.1      Project documentation with...
mkdocs-material              9.5.17    9.5.49     Documentation that simply ...
mkdocs-render-swagger-plugin 0.1.1     0.1.2      MKDocs plugin for renderin...
mkdocs-section-index         0.3.8     0.3.9      MkDocs plugin to allow cli...
mkdocstrings                 0.25.2    0.27.0     Automatic documentation fr...
mkdocstrings-python          1.10.9    1.12.2     A Python handler for mkdoc...
packaging                    23.2      24.2       Core utilities for Python ...
pre-commit                   2.21.0    4.0.1      A framework for managing a...
psutil                       5.9.8     6.1.0      Cross-platform lib for pro...
pydantic                     1.10.19   2.10.3     Data validation and settin...
pyjwt                        2.9.0     2.10.1     JSON Web Token implementat...
pytest                       8.1.2     8.3.4      pytest: simple powerful te...
pytest-asyncio               0.23.8    0.25.0     Pytest support for asyncio
python-multipart             0.0.17    0.0.20     A streaming multipart pars...
rfc3986                      1.5.0     2.0.0      Validating URI References ...
sqlmodel                     0.0.21    0.0.22     SQLModel, SQL databases in...
starlette                    0.41.3    0.42.0     The little ASGI library th...
uvicorn                      0.29.0    0.34.0     The lightning-fast ASGI se...
```

### Outdated dependencies _after_ PR:

```bash
asttokens                    2.4.1     3.0.0     Annotate AST trees with sou...
bumpver                      2022.1120 2024.1130 Bump version numbers in pro...
cloudpickle                  3.0.0     3.1.0     Pickler class to extend the...
coverage                     7.5.4     7.6.9     Code coverage measurement f...
gunicorn                     22.0.0    23.0.0    WSGI HTTP Server for UNIX
httpcore                     0.16.3    1.0.7     A minimal low-level HTTP cl...
httpx                        0.23.3    0.28.1    The next generation HTTP cl...
mkdocs                       1.5.3     1.6.1     Project documentation with ...
mkdocs-material              9.5.17    9.5.49    Documentation that simply w...
mkdocs-render-swagger-plugin 0.1.1     0.1.2     MKDocs plugin for rendering...
mkdocs-section-index         0.3.8     0.3.9     MkDocs plugin to allow clic...
mkdocstrings                 0.25.2    0.27.0    Automatic documentation fro...
mkdocstrings-python          1.10.9    1.12.2    A Python handler for mkdocs...
packaging                    23.2      24.2      Core utilities for Python p...
pre-commit                   2.21.0    4.0.1     A framework for managing an...
psutil                       5.9.8     6.1.0     Cross-platform lib for proc...
pydantic                     1.10.19   2.10.3    Data validation and setting...
pyjwt                        2.9.0     2.10.1    JSON Web Token implementati...
pytest                       8.1.2     8.3.4     pytest: simple powerful tes...
pytest-asyncio               0.23.8    0.25.0    Pytest support for asyncio
python-multipart             0.0.17    0.0.20    A streaming multipart parse...
rfc3986                      1.5.0     2.0.0     Validating URI References p...
sqlmodel                     0.0.21    0.0.22    SQLModel, SQL databases in ...
starlette                    0.41.3    0.42.0    The little ASGI library tha...
uvicorn                      0.29.0    0.34.0    The lightning-fast ASGI ser...
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._