### PR TITLE
[auto] Update dependencies in `poetry.lock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Testing:
     * Introduce benchmarks for database operations (\#2620).
 * Dependencies:
-    * Update `cryptography` and `packaging` dependencies (\#2630).
+    * Update `cryptography`, `packaging` and `python-dotenv` dependencies (\#2630).
 
 # 2.14.15
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2106,14 +2106,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.1"
+version = "1.1.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
-    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+    {file = "python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d"},
+    {file = "python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5"},
 ]
 
 [package.extras]
@@ -2750,4 +2750,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "4fdc3082eedaed7cee93ad553538c6250f88fbf8f733da61d18a9746bf88708d"
+content-hash = "4144752598838abe7ce7a9f56afa60070d49f652c82e10a768ab212740af4183"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "python-dotenv >=1.0.0,<1.1.0",
+    "python-dotenv >=1.1.0,<1.2.0",
     "fastapi >= 0.115.0, <0.116.0",
     "sqlmodel == 0.0.24",
     "sqlalchemy[asyncio] >=2.0.23,<2.1",


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 2 updates, 0 removals

  - Updating typing-extensions (4.13.2 -> 4.14.0)
  - Updating uvicorn (0.34.2 -> 0.34.3)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
argon2-cffi       23.1.0 25.1.0 Argon2 for Python
cryptography      44.0.3 45.0.3 cryptography is a package which provides cry...
packaging         24.2   25.0   Core utilities for Python packages
pydantic-core     2.33.2 2.34.1 Core functionality for Pydantic validation a...
python-dotenv     1.0.1  1.1.0  Read key-value pairs from a .env file and se...
starlette         0.46.2 0.47.0 The little ASGI library that shines.
typing-extensions 4.13.2 4.14.0 Backported and Experimental Type Hints for P...
uvicorn           0.34.2 0.34.3 The lightning-fast ASGI server.
```

### Outdated dependencies _after_ PR:

```bash
argon2-cffi   23.1.0 25.1.0 Argon2 for Python
cryptography  44.0.3 45.0.3 cryptography is a package which provides cryptog...
packaging     24.2   25.0   Core utilities for Python packages
pydantic-core 2.33.2 2.34.1 Core functionality for Pydantic validation and s...
python-dotenv 1.0.1  1.1.0  Read key-value pairs from a .env file and set th...
starlette     0.46.2 0.47.0 The little ASGI library that shines.
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._