### PR TITLE
Fix `test_unit_pypi_version`

### DIFF
--- a/tests/v2/test_03_api/test_unit_pypi_version.py
+++ b/tests/v2/test_03_api/test_unit_pypi_version.py
@@ -50,7 +50,7 @@ async def test_get_package_version_from_pypi_failures(monkeypatch):
 
     # Failure 2: invalid incomplete version
     with pytest.raises(HTTPException, match="No version starting"):
-        await get_package_version_from_pypi(PKG, version="1.2.2")
+        await get_package_version_from_pypi(PKG, version="1.2.3")
 
     # Failure 3: KeyError due to unexpected response (200, with wrong data)
     async def _patched_get_1(*args, **kwargs):


### PR DESCRIPTION
Fix due to new release on June 3, 2025
https://pypi.org/project/fractal-tasks-core/1.2.2/#history

## Checklist before merging
- [ ] I added an appropriate entry to `CHANGELOG.md`
- [ ] I added logging to new code - if appropriate.
- [ ] I merged `main` into the current branch.
