### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     * Replace `HTTP_422_UNPROCESSABLE_CONTENT` with `HTTP_422_UNPROCESSABLE_CONTENT` (\#2790).
 * Dependencies:
     * Bump `fastapi` version (\#2790).
-    * Bump `uvicorn-worker` version (\#2792).
+    * Bump `uvicorn-worker` and `sqlmodel` versions (\#2792).
 
 # 2.16.3
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2425,14 +2425,14 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "sqlmodel"
-version = "0.0.24"
+version = "0.0.25"
 description = "SQLModel, SQL databases in Python, designed for simplicity, compatibility, and robustness."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "sqlmodel-0.0.24-py3-none-any.whl", hash = "sha256:6778852f09370908985b667d6a3ab92910d0d5ec88adcaf23dbc242715ff7193"},
-    {file = "sqlmodel-0.0.24.tar.gz", hash = "sha256:cc5c7613c1a5533c9c7867e1aab2fd489a76c9e8a061984da11b4e613c182423"},
+    {file = "sqlmodel-0.0.25-py3-none-any.whl", hash = "sha256:c98234cda701fb77e9dcbd81688c23bb251c13bb98ce1dd8d4adc467374d45b7"},
+    {file = "sqlmodel-0.0.25.tar.gz", hash = "sha256:56548c2e645975b1ed94d6c53f0d13c85593f57926a575e2bf566650b2243fa4"},
 ]
 
 [package.dependencies]
@@ -2733,4 +2733,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "fadcf2ed8fca93ce54df2dff029f29559b833ddc7ea80d8abbe222a838a7f45a"
+content-hash = "5ed45ab3c26dafe33a8b833c9cd5d65808c410d5aeba1565c3951ab13ca1ee7d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     "python-dotenv >=1.1.0,<1.2.0",
     "fastapi >= 0.117.0, <0.118.0",
-    "sqlmodel == 0.0.24",
+    "sqlmodel == 0.0.25",
     "sqlalchemy[asyncio] >=2.0.23,<2.1",
     "fastapi-users[oauth] >=14,<15",
     "alembic >=1.13.1, <2.0.0",


### PR DESCRIPTION
### Updated dependencies:

```bash
Updating dependencies
Resolving dependencies...

Package operations: 0 installs, 1 update, 0 removals

  - Updating anyio (4.10.0 -> 4.11.0)

Writing lock file
```

### Outdated dependencies _before_ PR:

```bash
anyio           4.10.0 4.11.0 High-level concurrency and networking framewor...
argon2-cffi     23.1.0 25.1.0 Argon2 for Python
email-validator 2.2.0  2.3.0  A robust email address syntax and deliverabili...
pydantic-core   2.33.2 2.39.0 Core functionality for Pydantic validation and...
sqlmodel        0.0.24 0.0.25 SQLModel, SQL databases in Python, designed fo...
uvicorn         0.34.3 0.36.0 The lightning-fast ASGI server.
uvicorn-worker  0.3.0  0.4.0  Uvicorn worker for Gunicorn! ✨
```

### Outdated dependencies _after_ PR:

```bash
argon2-cffi     23.1.0 25.1.0 Argon2 for Python
email-validator 2.2.0  2.3.0  A robust email address syntax and deliverabili...
pydantic-core   2.33.2 2.39.0 Core functionality for Pydantic validation and...
sqlmodel        0.0.24 0.0.25 SQLModel, SQL databases in Python, designed fo...
uvicorn         0.34.3 0.36.0 The lightning-fast ASGI server.
uvicorn-worker  0.3.0  0.4.0  Uvicorn worker for Gunicorn! ✨
```

_Note: there may be dependencies in the table above which were not updated as part of this PR.
The reason is they require manual updating due to the way they are pinned._