### PR TITLE
Bump jinja2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Database:
     * Make task `(name, taskgroupv2_id)` unique (\#3362).
+* Dependencies:
+    * Require dev dependency `jinja2` 3.1.6 (\#3365).
 
 # 2.23.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "pytest-docker >=3.2.0,<3.3.0",
     "pytest-subprocess >=1.5.0,<1.6.0",
     "a2wsgi >=1.10.0,<1.11.0",
-    "jinja2 >=3.1.3,<3.1.4",
+    "jinja2 >=3.1.6,<3.1.7",
     "pyyaml>=6.0.0"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -656,7 +656,7 @@ oauth = [
 
 [[package]]
 name = "fractal-server"
-version = "2.22.14"
+version = "2.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -733,7 +733,7 @@ dev = [
     { name = "coverage", specifier = ">=7.12.0,<7.13.0" },
     { name = "devtools", specifier = "==0.12" },
     { name = "httpx", specifier = ">=0.28.0,<0.29.0" },
-    { name = "jinja2", specifier = ">=3.1.3,<3.1.4" },
+    { name = "jinja2", specifier = ">=3.1.6,<3.1.7" },
     { name = "pytest", specifier = ">=9.0.0,<9.1.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<1.4.0" },
     { name = "pytest-docker", specifier = ">=3.2.0,<3.3.0" },
@@ -911,14 +911,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.3"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261, upload-time = "2024-01-10T23:12:21.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa", size = 133236, upload-time = "2024-01-10T23:12:19.504Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Motivation:
```console
$ uv audit
warning: `uv audit` is experimental and may change without warning. Pass `--preview-features audit-command` to disable this warning.
Resolved 106 packages in 192ms
Found 4 known vulnerabilities and no adverse project statuses in 105 packages

Vulnerabilities:

jinja2 3.1.3 has 4 known vulnerabilities:

- GHSA-gmj6-6f8f-6699: Jinja has a sandbox breakout through malicious filenames

  Fixed in: 3.1.5

  Advisory information: https://nvd.nist.gov/vuln/detail/CVE-2024-56201

- GHSA-h75v-3vvj-5mfj: Jinja vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter

  Fixed in: 3.1.4

  Advisory information: https://nvd.nist.gov/vuln/detail/CVE-2024-34064

- GHSA-cpwx-vrp4-4pq7: Jinja2 vulnerable to sandbox breakout through attr filter selecting format method

  Fixed in: 3.1.6

  Advisory information: https://nvd.nist.gov/vuln/detail/CVE-2025-27516

- GHSA-q2x7-8rv6-6q7h: Jinja has a sandbox breakout through indirect reference to format method

  Fixed in: 3.1.5

  Advisory information: https://nvd.nist.gov/vuln/detail/CVE-2024-56326
```


## Checklist before merging into `main`

- [ ] I merged `main` into the current branch.
- [ ] I added an appropriate entry to `CHANGELOG.md`
- [ ] All GitHub checks completed successfully, or there are failures which are clearly unrelated to this Pull Request and I opened an issue about it.
- [ ] The reported "PR coverage" is 100%, or we briefly discussed why this is not the case.
- [ ] I added logging to new code - if appropriate.
- [ ] I added type hints to new code - if appropriate - and maybe I ran this command to spot some naive errors:
```bash
ty check $(git diff main --name-only ./fractal_server)
```
