### PR TITLE
Make CLI-functions imports lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+* CLI:
+    * Lazy-load dependencies for CLI commands (\#3421).
 * Documentation:
     * Add docs page about data access and `fractal-data` integration (\#3419).
 

--- a/fractal_server/cli/_aux_sync_core_tasks.py
+++ b/fractal_server/cli/_aux_sync_core_tasks.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from pydantic import RootModel
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from fractal_server.app.models import TaskV2
+from fractal_server.types import NonEmptyStr
+
+_SetThreeStringsTuple = set[
+    tuple[
+        NonEmptyStr,
+        NonEmptyStr,
+        NonEmptyStr,
+    ]
+]
+
+
+class _CoreInfoSet(RootModel):
+    """
+    Set of `(pkg_name, version, task_name)` tuples.
+    """
+
+    root: _SetThreeStringsTuple
+
+
+def _read_set_from_file(path: Path | None) -> _SetThreeStringsTuple:
+    """
+    Read a file (if any) and parse into a set of core-task info items.
+    """
+    json_data = path.read_text() if path else "[]"
+    return _CoreInfoSet.model_validate_json(json_data).root
+
+
+def _get_final_set(
+    *,
+    base: Path | None = None,
+    add: Path | None = None,
+    remove: Path | None = None,
+) -> _SetThreeStringsTuple:
+    base_set = _read_set_from_file(base)
+    add_set = _read_set_from_file(add)
+    remove_set = _read_set_from_file(remove)
+    final_set = (base_set.union(add_set)).difference(remove_set)
+    return final_set
+
+
+def _count_core_tasks(db_sync: Session) -> int:
+    """
+    Count core tasks.
+    """
+    count_stm = select(func.count(TaskV2.id)).where(TaskV2.is_core.is_(True))
+    res = db_sync.execute(count_stm)
+    return res.scalar_one()

--- a/fractal_server/cli/_init_db_data.py
+++ b/fractal_server/cli/_init_db_data.py
@@ -1,23 +1,3 @@
-import asyncio
-import json
-import sys
-from pathlib import Path
-
-from pydantic import ValidationError
-from sqlalchemy import func
-from sqlalchemy import select
-
-from fractal_server.app.db import get_sync_db
-from fractal_server.app.models import Profile
-from fractal_server.app.models import Resource
-from fractal_server.app.models.security import UserOAuth
-from fractal_server.app.schemas.v2 import ResourceType
-from fractal_server.app.schemas.v2.profile import cast_serialize_profile
-from fractal_server.app.schemas.v2.resource import cast_serialize_resource
-from fractal_server.app.security import _create_first_group
-from fractal_server.app.security import _create_first_user
-
-
 def init_db_data(
     *,
     resource: str | None = None,
@@ -26,6 +6,25 @@ def init_db_data(
     admin_password: str | None = None,
     admin_project_dir: str | None = None,
 ) -> None:
+    import asyncio
+    import json
+    import sys
+    from pathlib import Path
+
+    from pydantic import ValidationError
+    from sqlalchemy import func
+    from sqlalchemy import select
+
+    from fractal_server.app.db import get_sync_db
+    from fractal_server.app.models import Profile
+    from fractal_server.app.models import Resource
+    from fractal_server.app.models.security import UserOAuth
+    from fractal_server.app.schemas.v2 import ResourceType
+    from fractal_server.app.schemas.v2.profile import cast_serialize_profile
+    from fractal_server.app.schemas.v2.resource import cast_serialize_resource
+    from fractal_server.app.security import _create_first_group
+    from fractal_server.app.security import _create_first_user
+
     # Create default group and user
     print()
     _create_first_group()

--- a/fractal_server/cli/_openapi.py
+++ b/fractal_server/cli/_openapi.py
@@ -1,12 +1,11 @@
-import json
-from typing import Any
-
-from fastapi import FastAPI
-
-from fractal_server.main import start_application
-
-
 def save_openapi(dest: str = "openapi.json") -> None:
+    import json
+    from typing import Any
+
+    from fastapi import FastAPI
+
+    from fractal_server.main import start_application
+
     app: FastAPI = start_application()
     openapi_schema: dict[str, Any] = app.openapi()
 

--- a/fractal_server/cli/_recent.py
+++ b/fractal_server/cli/_recent.py
@@ -1,21 +1,20 @@
-import datetime
-
-from sqlalchemy.sql.operators import is_not
-from sqlmodel import and_
-from sqlmodel import case
-from sqlmodel import or_
-from sqlmodel import select
-
-from fractal_server.app.db import get_sync_db
-from fractal_server.app.models import JobV2
-from fractal_server.app.models import TaskGroupActivityV2
-from fractal_server.app.models import UserOAuth
-from fractal_server.app.schemas.v2.job import JobStatusType
-from fractal_server.app.schemas.v2.task_group import TaskGroupActivityStatus
-from fractal_server.utils import get_timestamp
-
-
 def recent(*, minutes: int) -> None:
+    import datetime
+
+    from sqlalchemy.sql.operators import is_not
+    from sqlmodel import and_
+    from sqlmodel import case
+    from sqlmodel import or_
+    from sqlmodel import select
+
+    from fractal_server.app.db import get_sync_db
+    from fractal_server.app.models import JobV2
+    from fractal_server.app.models import TaskGroupActivityV2
+    from fractal_server.app.models import UserOAuth
+    from fractal_server.app.schemas.v2.job import JobStatusType
+    from fractal_server.app.schemas.v2.task_group import TaskGroupActivityStatus
+    from fractal_server.utils import get_timestamp
+
     def format_timestamp(timestamp: datetime.datetime | None) -> str:
         if timestamp is None:
             return "-"

--- a/fractal_server/cli/_set_db.py
+++ b/fractal_server/cli/_set_db.py
@@ -1,12 +1,3 @@
-from pathlib import Path
-
-import alembic.config
-
-import fractal_server
-from fractal_server.config import get_db_settings
-from fractal_server.syringe import Inject
-
-
 def set_db() -> None:
     """
     Upgrade database schemas.
@@ -14,6 +5,14 @@ def set_db() -> None:
     Call alembic to upgrade to the latest migration.
     Ref: https://stackoverflow.com/a/56683030/283972
     """
+
+    from pathlib import Path
+
+    import alembic.config
+
+    import fractal_server
+    from fractal_server.config import get_db_settings
+    from fractal_server.syringe import Inject
 
     # Validate DB settings
     Inject(get_db_settings)

--- a/fractal_server/cli/_start.py
+++ b/fractal_server/cli/_start.py
@@ -1,12 +1,11 @@
-import uvicorn
-
-
 def start(
     *,
     host: str,
     port: int,
     reload: bool,
 ):
+    import uvicorn
+
     uvicorn.run(
         "fractal_server.main:app",
         host=host,

--- a/fractal_server/cli/_sync_core_tasks.py
+++ b/fractal_server/cli/_sync_core_tasks.py
@@ -1,68 +1,4 @@
-import json
-import sys
 from pathlib import Path
-
-from pydantic import RootModel
-from sqlalchemy import func
-from sqlalchemy import select
-from sqlalchemy import update
-from sqlalchemy.orm import Session
-
-from fractal_server.app.db import get_sync_db
-from fractal_server.app.models import Resource
-from fractal_server.app.models import TaskGroupV2
-from fractal_server.app.models import TaskV2
-from fractal_server.app.models import UserGroup
-from fractal_server.config import get_email_settings
-from fractal_server.send_mail import send_fractal_email_or_log_failure
-from fractal_server.syringe import Inject
-from fractal_server.types import NonEmptyStr
-
-_SetThreeStringsTuple = set[
-    tuple[
-        NonEmptyStr,
-        NonEmptyStr,
-        NonEmptyStr,
-    ]
-]
-
-
-class _CoreInfoSet(RootModel):
-    """
-    Set of `(pkg_name, version, task_name)` tuples.
-    """
-
-    root: _SetThreeStringsTuple
-
-
-def _read_set_from_file(path: Path | None) -> _SetThreeStringsTuple:
-    """
-    Read a file (if any) and parse into a set of core-task info items.
-    """
-    json_data = path.read_text() if path else "[]"
-    return _CoreInfoSet.model_validate_json(json_data).root
-
-
-def _get_final_set(
-    *,
-    base: Path | None = None,
-    add: Path | None = None,
-    remove: Path | None = None,
-) -> _SetThreeStringsTuple:
-    base_set = _read_set_from_file(base)
-    add_set = _read_set_from_file(add)
-    remove_set = _read_set_from_file(remove)
-    final_set = (base_set.union(add_set)).difference(remove_set)
-    return final_set
-
-
-def _count_core_tasks(db_sync: Session) -> int:
-    """
-    Count core tasks.
-    """
-    count_stm = select(func.count(TaskV2.id)).where(TaskV2.is_core.is_(True))
-    res = db_sync.execute(count_stm)
-    return res.scalar_one()
 
 
 def sync_core_tasks(
@@ -76,6 +12,70 @@ def sync_core_tasks(
     Update the set of tasks marked as core in the database, based on on-disk
     configuration files.
     """
+
+    import json
+    import sys
+
+    from pydantic import RootModel
+    from sqlalchemy import func
+    from sqlalchemy import select
+    from sqlalchemy import update
+    from sqlalchemy.orm import Session
+
+    from fractal_server.app.db import get_sync_db
+    from fractal_server.app.models import Resource
+    from fractal_server.app.models import TaskGroupV2
+    from fractal_server.app.models import TaskV2
+    from fractal_server.app.models import UserGroup
+    from fractal_server.config import get_email_settings
+    from fractal_server.send_mail import send_fractal_email_or_log_failure
+    from fractal_server.syringe import Inject
+    from fractal_server.types import NonEmptyStr
+
+    _SetThreeStringsTuple = set[
+        tuple[
+            NonEmptyStr,
+            NonEmptyStr,
+            NonEmptyStr,
+        ]
+    ]
+
+    class _CoreInfoSet(RootModel):
+        """
+        Set of `(pkg_name, version, task_name)` tuples.
+        """
+
+        root: _SetThreeStringsTuple
+
+    def _read_set_from_file(path: Path | None) -> _SetThreeStringsTuple:
+        """
+        Read a file (if any) and parse into a set of core-task info items.
+        """
+        json_data = path.read_text() if path else "[]"
+        return _CoreInfoSet.model_validate_json(json_data).root
+
+    def _get_final_set(
+        *,
+        base: Path | None = None,
+        add: Path | None = None,
+        remove: Path | None = None,
+    ) -> _SetThreeStringsTuple:
+        base_set = _read_set_from_file(base)
+        add_set = _read_set_from_file(add)
+        remove_set = _read_set_from_file(remove)
+        final_set = (base_set.union(add_set)).difference(remove_set)
+        return final_set
+
+    def _count_core_tasks(db_sync: Session) -> int:
+        """
+        Count core tasks.
+        """
+        count_stm = select(func.count(TaskV2.id)).where(
+            TaskV2.is_core.is_(True)
+        )
+        res = db_sync.execute(count_stm)
+        return res.scalar_one()
+
     resources_and_groups: list[dict[str, int]] = json.loads(
         resources_and_groups.read_text()
     )

--- a/fractal_server/cli/_sync_core_tasks.py
+++ b/fractal_server/cli/_sync_core_tasks.py
@@ -16,11 +16,8 @@ def sync_core_tasks(
     import json
     import sys
 
-    from pydantic import RootModel
-    from sqlalchemy import func
     from sqlalchemy import select
     from sqlalchemy import update
-    from sqlalchemy.orm import Session
 
     from fractal_server.app.db import get_sync_db
     from fractal_server.app.models import Resource
@@ -30,51 +27,9 @@ def sync_core_tasks(
     from fractal_server.config import get_email_settings
     from fractal_server.send_mail import send_fractal_email_or_log_failure
     from fractal_server.syringe import Inject
-    from fractal_server.types import NonEmptyStr
 
-    _SetThreeStringsTuple = set[
-        tuple[
-            NonEmptyStr,
-            NonEmptyStr,
-            NonEmptyStr,
-        ]
-    ]
-
-    class _CoreInfoSet(RootModel):
-        """
-        Set of `(pkg_name, version, task_name)` tuples.
-        """
-
-        root: _SetThreeStringsTuple
-
-    def _read_set_from_file(path: Path | None) -> _SetThreeStringsTuple:
-        """
-        Read a file (if any) and parse into a set of core-task info items.
-        """
-        json_data = path.read_text() if path else "[]"
-        return _CoreInfoSet.model_validate_json(json_data).root
-
-    def _get_final_set(
-        *,
-        base: Path | None = None,
-        add: Path | None = None,
-        remove: Path | None = None,
-    ) -> _SetThreeStringsTuple:
-        base_set = _read_set_from_file(base)
-        add_set = _read_set_from_file(add)
-        remove_set = _read_set_from_file(remove)
-        final_set = (base_set.union(add_set)).difference(remove_set)
-        return final_set
-
-    def _count_core_tasks(db_sync: Session) -> int:
-        """
-        Count core tasks.
-        """
-        count_stm = select(func.count(TaskV2.id)).where(
-            TaskV2.is_core.is_(True)
-        )
-        res = db_sync.execute(count_stm)
-        return res.scalar_one()
+    from ._aux_sync_core_tasks import _count_core_tasks
+    from ._aux_sync_core_tasks import _get_final_set
 
     resources_and_groups: list[dict[str, int]] = json.loads(
         resources_and_groups.read_text()

--- a/fractal_server/cli/_update_db_data.py
+++ b/fractal_server/cli/_update_db_data.py
@@ -1,16 +1,15 @@
-import os
-import sys
-from importlib import import_module
-
-from packaging.version import parse
-
-import fractal_server
-
-
 def update_db_data() -> None:
     """
     Apply data migrations.
     """
+
+    import os
+    import sys
+    from importlib import import_module
+
+    from packaging.version import parse
+
+    import fractal_server
 
     def _slugify_version(raw_version: str) -> str:
         v = parse(raw_version)

--- a/tests/no_version/cli/test_sync_core_tasks.py
+++ b/tests/no_version/cli/test_sync_core_tasks.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from fractal_server.cli._sync_core_tasks import _count_core_tasks
-from fractal_server.cli._sync_core_tasks import _get_final_set
+from fractal_server.cli._aux_sync_core_tasks import _count_core_tasks
+from fractal_server.cli._aux_sync_core_tasks import _get_final_set
 from fractal_server.cli._sync_core_tasks import sync_core_tasks
 
 


### PR DESCRIPTION
This is to make the CLI more responsive.

Here is a example running locally, before the PR
```console
$ time uv run fractalctl --help
[...]

real	0m1.097s
user	0m1.019s
sys	    0m0.065s
```
and after the changes
```console
$ time uv run fractalctl --help
[...]

real	0m0.056s
user	0m0.033s
sys	    0m0.015s
```

The same issue was affecting a docs script, before the PR
```console
$ time uv run python docs/scripts/generate_cli_ref.py 
[...]

real	0m8.551s
user	0m8.121s
sys    	0m0.393s

```
and after the change
```console
$ time uv run python docs/scripts/generate_cli_ref.py 
[...]

real	0m0.246s
user	0m0.177s
sys	    0m0.061s
```


## Checklist before merging into `main`

- [x] I merged `main` into the current branch.
- [x] I added an appropriate entry to `CHANGELOG.md`
- [x] All GitHub checks completed successfully, or there are failures which are clearly unrelated to this Pull Request and I opened an issue about it.
- [ ] The reported "PR coverage" is 100%, or we briefly discussed why this is not the case.
- [ ] I added logging to new code - if appropriate.
- [ ] I added type hints to new code - if appropriate - and maybe I ran this command to spot some naive errors:
```bash
ty check $(git diff main --name-only ./fractal_server)
```
